### PR TITLE
Feature/amp/amp 33 inline css

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibraryImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibraryImpl.java
@@ -1,0 +1,84 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import com.adobe.cq.wcm.core.components.internal.models.v2.PageImpl;
+import com.adobe.cq.wcm.core.components.models.ClientLibrary;
+import com.adobe.cq.wcm.core.components.services.ClientLibraryAggregatorService;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.designer.Style;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+
+/**
+ * @since com.adobe.cq.wcm.core.components.models 12.11.0
+ */
+@Model(adaptables = {Resource.class, SlingHttpServletRequest.class},
+    adapters = {ClientLibrary.class},
+    defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
+public class ClientLibraryImpl implements ClientLibrary {
+
+    @Inject
+    private String categories;
+
+    @Inject
+    private String type;
+
+    @OSGiService
+    private ClientLibraryAggregatorService clientLibraryAggregatorService;
+
+    @ScriptVariable
+    private Page currentPage;
+
+    @ScriptVariable
+    private Style currentStyle;
+
+    @Override
+    public String getInline() {
+        String baseClientLibrary = currentStyle.get("appResourcesClientlib", String.class);
+        return clientLibraryAggregatorService.getClientLibOutput(baseClientLibrary, categories, type);
+    }
+
+    @Override
+    public String getInlineLimited() {
+        String baseClientLibrary = currentStyle.get("appResourcesClientlib", String.class);
+        Set<String> resourceTypes = getResourceTypes(currentPage.getContentResource(), new HashSet<>());
+        return clientLibraryAggregatorService.getClientLibOutput(baseClientLibrary, resourceTypes, type);
+    }
+
+    private Set<String> getResourceTypes(Resource resource, Set<String> resourceTypes) {
+        resourceTypes.add(resource.getResourceType());
+        if (resource.hasChildren()) {
+            for (Resource child : resource.getChildren()) {
+                resourceTypes.add(child.getResourceType());
+                if (child.hasChildren()) {
+                    getResourceTypes(child, resourceTypes);
+                }
+            }
+        }
+        return resourceTypes;
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImpl.java
@@ -1,0 +1,148 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.adobe.cq.wcm.core.components.services.ClientLibraryAggregatorService;
+import com.adobe.granite.ui.clientlibs.ClientLibrary;
+import com.adobe.granite.ui.clientlibs.HtmlLibrary;
+import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
+import com.adobe.granite.ui.clientlibs.LibraryType;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @since com.adobe.cq.wcm.core.components.models 12.11.0
+ */
+@Component(service = ClientLibraryAggregatorService.class)
+public class ClientLibraryAggregatorServiceImpl implements ClientLibraryAggregatorService {
+
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private Map<String, LibraryType> libraryTypeMap = generateTypeMap();
+
+    @Reference
+    private HtmlLibraryManager htmlLibraryManager;
+
+    @Reference
+    private ResourceResolverFactory resolverFactory;
+
+    @Override
+    public String getClientLibOutput(String baseCategory, String categoryString, String type) {
+        List<String> categoriesToSearch = new ArrayList<>();
+        if (StringUtils.isNotBlank(baseCategory)) {
+            categoriesToSearch.add(baseCategory);
+        }
+        if (categoryString != null && categoryString.contains(",")) {
+            categoriesToSearch.addAll(Arrays.asList(categoryString.split(",")));
+        } else if (categoryString != null) {
+            categoriesToSearch.add(categoryString);
+        }
+        LibraryType libraryType = libraryTypeMap.get(type);
+        Collection<ClientLibrary> libraries = htmlLibraryManager
+            .getLibraries(categoriesToSearch.toArray(new String[]{}), libraryType, false, true);
+        StringBuilder sb = new StringBuilder();
+        for (ClientLibrary clientlib : libraries) {
+            HtmlLibrary library = htmlLibraryManager.getLibrary(libraryType, clientlib.getPath());
+            if (library != null) {
+                try {
+                    sb.append(IOUtils.toString(library.getInputStream(true)));
+                } catch (IOException e) {
+                    log.error("Error getting input stream from clientlib with path ", clientlib.getPath());
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String getClientLibOutput(String baseCategory, Set<String> resourceTypes, String type) {
+        List<String> categories = new ArrayList<>();
+        try (ResourceResolver resourceResolver = getServiceResourceResolver()) {
+            if (resourceResolver == null) {
+                log.error("Service user doesn't exist.");
+                return null;
+            }
+            for (String resType : resourceTypes) {
+                Resource resource = getResource(resourceResolver, resType);
+                if (resource != null && resource.getChild("clientlibs") != null) {
+                    Resource ampClientlib = resource.getChild("clientlibs/amp-clientlib");
+                    if (ampClientlib == null) {
+                        continue;
+                    }
+                    String[] componentCategories = ampClientlib.getValueMap().get("categories", String[].class);
+                    if (componentCategories != null) {
+                        categories.addAll(Arrays.asList(componentCategories));
+                    }
+                }
+            }
+        }
+        return getClientLibOutput(baseCategory, StringUtils.join(categories, ","), type);
+    }
+
+    private Resource getResource(ResourceResolver resourceResolver, String resourceType) {
+        String[] searchPaths = resourceResolver.getSearchPath();
+        for (String path : searchPaths) {
+            Resource resource = resourceResolver.getResource(path + resourceType);
+            if (resource != null) {
+                return resource;
+            }
+        }
+        return null;
+    }
+
+    private Map<String, LibraryType> generateTypeMap() {
+        Map<String, LibraryType> map = new HashMap<>();
+        map.put("css", LibraryType.CSS);
+        map.put("js", LibraryType.JS);
+        return map;
+    }
+
+    /**
+     * Obtains a service resource resolver.
+     *
+     * @return {@link ResourceResolver} instance
+     * @throws LoginException exception if it cannot get the resource resolver object.
+     */
+    private ResourceResolver getServiceResourceResolver() {
+        Map<String, Object> param = new HashMap<>();
+        param.put(ResourceResolverFactory.SUBSERVICE, "component-clientlib-service");
+
+        try {
+            return resolverFactory.getServiceResourceResolver(param);
+        } catch (LoginException e) {
+            log.error("Unable to get the service resource resolver.");
+        }
+        return null;
+    }
+}
+

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImpl.java
@@ -16,13 +16,8 @@
 package com.adobe.cq.wcm.core.components.internal.services;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 
 import com.adobe.cq.wcm.core.components.services.ClientLibraryAggregatorService;
 import com.adobe.granite.ui.clientlibs.ClientLibrary;
@@ -36,19 +31,34 @@ import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.*;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * @since com.adobe.cq.wcm.core.components.models 12.11.0
  */
-@Component(service = ClientLibraryAggregatorService.class)
+@Component(service = ClientLibraryAggregatorService.class,
+    configurationPolicy = ConfigurationPolicy.REQUIRE)
+@Designate(
+    ocd = ClientLibraryAggregatorServiceImpl.Cfg.class
+)
 public class ClientLibraryAggregatorServiceImpl implements ClientLibraryAggregatorService {
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
-    private Map<String, LibraryType> libraryTypeMap = generateTypeMap();
+    private static final Logger LOG = LoggerFactory.getLogger(ClientLibraryAggregatorServiceImpl.class);
+
+    private static final String CATEGORIES = "categories";
+
+    private static Map<String, LibraryType> libraryTypeMap;
+
+    static {
+        libraryTypeMap = new HashMap<>();
+        libraryTypeMap.put("css", LibraryType.CSS);
+        libraryTypeMap.put("js", LibraryType.JS);
+    }
 
     @Reference
     private HtmlLibraryManager htmlLibraryManager;
@@ -56,93 +66,195 @@ public class ClientLibraryAggregatorServiceImpl implements ClientLibraryAggregat
     @Reference
     private ResourceResolverFactory resolverFactory;
 
+    private Cfg cfg;
+
+    /**
+     * Reads the service's configuration when the service is started.
+     * @param cfg The service's configuration.
+     */
+    @Activate
+    @Modified
+    protected void activate(Cfg cfg) {
+        this.cfg = cfg;
+    }
+
+    /**
+     * Returns the aggregated content of the specified clientlib type from the given comma delimited list of categories.
+     * @param categoryCsv Comma delimited list of clientlib categories to read the content from.
+     * @param type The type of clientlib content to retrieve. Typically 'css' or 'js'.
+     * @return String of all aggregated clientlib content.
+     */
     @Override
-    public String getClientLibOutput(String baseCategory, String categoryString, String type) {
-        List<String> categoriesToSearch = new ArrayList<>();
-        if (StringUtils.isNotBlank(baseCategory)) {
-            categoriesToSearch.add(baseCategory);
+    public String getClientLibOutput(String categoryCsv, String type) {
+
+        // Validate the parameters.
+        if (StringUtils.isBlank(categoryCsv)) {
+            return "";
         }
-        if (categoryString != null && categoryString.contains(",")) {
-            categoriesToSearch.addAll(Arrays.asList(categoryString.split(",")));
-        } else if (categoryString != null) {
-            categoriesToSearch.add(categoryString);
+        if (!libraryTypeMap.containsKey(type)) {
+            LOG.error("No client libraries of type '{}'.", type);
+            return "";
         }
+
+        // Parse the array of categories from the comma delimited category string.
+        String[] categories;
+        if (categoryCsv.contains(",")) {
+            categories = categoryCsv.split(",");
+        } else {
+            categories = new String[] {categoryCsv};
+        }
+
+        // Retrieve the clientlibs of the categories of the specified type.
         LibraryType libraryType = libraryTypeMap.get(type);
-        Collection<ClientLibrary> libraries = htmlLibraryManager
-            .getLibraries(categoriesToSearch.toArray(new String[]{}), libraryType, false, true);
-        StringBuilder sb = new StringBuilder();
+        Collection<ClientLibrary> libraries = htmlLibraryManager.getLibraries(categories, libraryType, false, true);
+
+        // Iterate through the clientlibs and aggregate their content.
+        StringBuilder output = new StringBuilder();
         for (ClientLibrary clientlib : libraries) {
             HtmlLibrary library = htmlLibraryManager.getLibrary(libraryType, clientlib.getPath());
             if (library != null) {
                 try {
-                    sb.append(IOUtils.toString(library.getInputStream(true)));
+                    output.append(IOUtils.toString(library.getInputStream(htmlLibraryManager.isMinifyEnabled()),
+                        StandardCharsets.UTF_8));
                 } catch (IOException e) {
-                    log.error("Error getting input stream from clientlib with path ", clientlib.getPath());
+                    LOG.error("Error getting input stream from clientlib with path '{}'.", clientlib.getPath());
                 }
             }
         }
-        return sb.toString();
+
+        return output.toString();
     }
 
+    /**
+     * Returns the aggregated content of the specified clientlib type from the given categories and all categories of
+     * the given resource types.
+     * @param categoryCsv Comma separated list of clientlib categories to include.
+     * @param type The type of clientlib content to retrieve. Typically 'css' or 'js'.
+     * @param resourceTypes The set of resource types to retrieve clientlib content for.
+     * @param primaryPath The relative path of the target clientlibs from the given resource types.
+     * @param fallbackPath The relative path of the target clientlibs from the given resource types if none is found
+     *                     using the primary path.
+     * @return String of all aggregated clientlib content.
+     */
     @Override
-    public String getClientLibOutput(String baseCategory, Set<String> resourceTypes, String type) {
+    public String getClientLibOutput(String categoryCsv, String type, Set<String> resourceTypes, String primaryPath,
+                                     String fallbackPath) {
+
+        // Validate the given path values.
+        boolean primaryPathBlank = StringUtils.isBlank(primaryPath);
+        boolean fallbackPathBlank = StringUtils.isBlank(fallbackPath);
+        if (primaryPathBlank && fallbackPathBlank) {
+            LOG.debug("Resource type clientlib aggregator must have a path value.");
+            return "";
+        }
+
+        // Initialize the category list with the comma separated category values.
         List<String> categories = new ArrayList<>();
-        try (ResourceResolver resourceResolver = getServiceResourceResolver()) {
-            if (resourceResolver == null) {
-                log.error("Service user doesn't exist.");
-                return null;
+        if (StringUtils.isNotBlank(categoryCsv)) {
+            if (categoryCsv.contains(",")) {
+                Collections.addAll(categories, categoryCsv.split(","));
+            } else {
+                categories.add(categoryCsv);
             }
-            for (String resType : resourceTypes) {
-                Resource resource = getResource(resourceResolver, resType);
-                if (resource != null && resource.getChild("clientlibs") != null) {
-                    Resource ampClientlib = resource.getChild("clientlibs/amp-clientlib");
-                    if (ampClientlib == null) {
+        }
+
+        try (ResourceResolver resourceResolver = getServiceResourceResolver()) {
+
+            // Iterate through each resource type and retrieve its clientlib categories.
+            for (String resourceType : resourceTypes) {
+
+                Resource resource = getResourceType(resourceResolver, resourceType);
+                if (resource == null) {
+                    continue;
+                }
+
+                // Resolve the resource type's clientlib.
+                Resource clientlib = null;
+                if (!primaryPathBlank) {
+                    clientlib = resource.getChild(primaryPath);
+                }
+                if (clientlib == null) {
+                    if (!fallbackPathBlank) {
+                        clientlib = resource.getChild(fallbackPath);
+                        if (clientlib == null) {
+                            continue;
+                        }
+                    } else {
                         continue;
                     }
-                    String[] componentCategories = ampClientlib.getValueMap().get("categories", String[].class);
-                    if (componentCategories != null) {
-                        categories.addAll(Arrays.asList(componentCategories));
-                    }
+                }
+
+                // Retrieve the resource type's clientlib categories.
+                String[] resourceCategories = clientlib.getValueMap().get(CATEGORIES, String[].class);
+                if (resourceCategories != null) {
+                    categories.addAll(Arrays.asList(resourceCategories));
                 }
             }
+        } catch (LoginException e) {
+            LOG.error("Unable to get the service resource resolver.");
         }
-        return getClientLibOutput(baseCategory, StringUtils.join(categories, ","), type);
+
+        return getClientLibOutput(StringUtils.join(categories, ","), type);
     }
 
-    private Resource getResource(ResourceResolver resourceResolver, String resourceType) {
-        String[] searchPaths = resourceResolver.getSearchPath();
-        for (String path : searchPaths) {
-            Resource resource = resourceResolver.getResource(path + resourceType);
+    /**
+     * Resolves the resource of a relative resource type path.
+     * @param resolver Provides search paths used to turn relative paths to full paths and resolves the resource.
+     * @param resourceType The resource type to resolve.
+     * @return The resource of the resource type path.
+     */
+    private Resource getResourceType(ResourceResolver resolver, String resourceType) {
+
+        Resource testResource = resolver.getResource(resourceType);
+
+        if (testResource != null) {
+            LOG.debug(testResource.getPath());
+        }
+
+        for (String path : resolver.getSearchPath()) {
+
+            Resource resource = resolver.getResource(path + resourceType);
             if (resource != null) {
                 return resource;
             }
         }
-        return null;
-    }
 
-    private Map<String, LibraryType> generateTypeMap() {
-        Map<String, LibraryType> map = new HashMap<>();
-        map.put("css", LibraryType.CSS);
-        map.put("js", LibraryType.JS);
-        return map;
+        return null;
     }
 
     /**
      * Obtains a service resource resolver.
-     *
      * @return {@link ResourceResolver} instance
-     * @throws LoginException exception if it cannot get the resource resolver object.
+     * @throws LoginException if it cannot get the resource resolver object.
      */
-    private ResourceResolver getServiceResourceResolver() {
+    private ResourceResolver getServiceResourceResolver() throws LoginException {
+
         Map<String, Object> param = new HashMap<>();
         param.put(ResourceResolverFactory.SUBSERVICE, "component-clientlib-service");
 
-        try {
-            return resolverFactory.getServiceResourceResolver(param);
-        } catch (LoginException e) {
-            log.error("Unable to get the service resource resolver.");
-        }
-        return null;
+        return resolverFactory.getServiceResourceResolver(param);
+    }
+
+    /**
+     * Checks if the given resource type path is allowed by the services configured resource type regex.
+     * @param resourceType The resource type path to check.
+     * @return If the given resource type is valid.
+     */
+    @Override
+    public boolean isValidResourceType(String resourceType) {
+        return StringUtils.isBlank(cfg.getResourceTypeRegex()) || resourceType.matches(cfg.getResourceTypeRegex());
+    }
+
+    @ObjectClassDefinition(name = "Client Library Aggregator Service")
+    public @interface Cfg {
+
+        /**
+         * Regex defining valid resource type paths while aggregating client libraries.
+         */
+        @AttributeDefinition(
+            name = "Resource Type Regex",
+            description = "Regex defining valid resource type paths while aggregating client libraries.")
+        String getResourceTypeRegex();
     }
 }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImpl.java
@@ -163,19 +163,14 @@ public class ClientLibraryAggregatorServiceImpl implements ClientLibraryAggregat
             // Iterate through each resource type and retrieve its clientlib categories.
             for (String resourceType : resourceTypes) {
 
-                Resource resource = getResourceType(resourceResolver, resourceType);
-                if (resource == null) {
-                    continue;
-                }
-
                 // Resolve the resource type's clientlib.
                 Resource clientlib = null;
                 if (!primaryPathBlank) {
-                    clientlib = resource.getChild(primaryPath);
+                    clientlib = resolveClientlib(resourceResolver, resourceType + "/" + primaryPath);
                 }
                 if (clientlib == null) {
                     if (!fallbackPathBlank) {
-                        clientlib = resource.getChild(fallbackPath);
+                        clientlib = resolveClientlib(resourceResolver, resourceType + "/" + fallbackPath);
                         if (clientlib == null) {
                             continue;
                         }
@@ -198,22 +193,22 @@ public class ClientLibraryAggregatorServiceImpl implements ClientLibraryAggregat
     }
 
     /**
-     * Resolves the resource of a relative resource type path.
+     * Resolves the resource of a relative clientlib.
      * @param resolver Provides search paths used to turn relative paths to full paths and resolves the resource.
-     * @param resourceType The resource type to resolve.
+     * @param clientlibPath The path of the clientlib to resolve.
      * @return The resource of the resource type path.
      */
-    private Resource getResourceType(ResourceResolver resolver, String resourceType) {
+    private Resource resolveClientlib(ResourceResolver resolver, String clientlibPath) {
 
-        Resource testResource = resolver.getResource(resourceType);
-
-        if (testResource != null) {
-            LOG.debug(testResource.getPath());
+        // Resolve absolute client lib path.
+        if (clientlibPath.startsWith("/")) {
+            return resolver.getResource(clientlibPath);
         }
 
+        // Resolve relative client lib path.
         for (String path : resolver.getSearchPath()) {
 
-            Resource resource = resolver.getResource(path + resourceType);
+            Resource resource = resolver.getResource(path + clientlibPath);
             if (resource != null) {
                 return resource;
             }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpHelperUtil.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpHelperUtil.java
@@ -1,0 +1,100 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.amp;
+
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.policies.ContentPolicy;
+import com.day.cq.wcm.api.policies.ContentPolicyManager;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides common value constants and methods used across AMP services.
+ */
+class AmpHelperUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AmpHelperUtil.class);
+
+    private static final String AMP_MODE_PROP = "ampMode";
+
+    private static final String NO_OVERRIDE = "noOverride";
+
+    static final String AMP_ONLY = "ampOnly";
+
+    static final String AMP_SELECTOR = "amp";
+
+    static final String DOT = ".";
+
+    static final String NO_AMP = "noAmp";
+
+    /**
+     * Retrieves the AMP mode value of the requested resource.
+     * @param slingRequest Request used to resolve the resource and AMP mode value from.
+     * @return The AMP mode value.
+     */
+    static String getAmpMode(@NotNull SlingHttpServletRequest slingRequest) {
+
+        PageManager pageManager = slingRequest.getResourceResolver().adaptTo(PageManager.class);
+
+        if (pageManager == null) {
+            LOG.debug("Can't resolve page manager. Falling back to content policy AMP mode.");
+            return getPolicyProperty(AMP_MODE_PROP, "", slingRequest);
+        }
+
+        Page page = pageManager.getContainingPage(slingRequest.getResource());
+
+        if (page != null) {
+
+            String ampMode = page.getProperties().get(AMP_MODE_PROP, "");
+
+            if (!ampMode.isEmpty() && !ampMode.equals(NO_OVERRIDE)) {
+                return ampMode;
+            }
+        }
+
+        return getPolicyProperty(AMP_MODE_PROP, "", slingRequest);
+    }
+
+    /**
+     * Retrieves the value of the given property from the request resource's content policy.
+     * @param property The name of the property to read.
+     * @param defaultValue The type hint and default value returned.
+     * @param slingRequest The request used to get the resource and its content policy.
+     * @param <T> The type of the property value expected.
+     * @return The value of the property of the resource's content policy. Returns null if fails to read the content
+     * policy.
+     */
+    private static <T> T getPolicyProperty(String property, T defaultValue,
+                                           @NotNull SlingHttpServletRequest slingRequest) {
+
+        ContentPolicyManager policyManager = slingRequest.getResourceResolver().adaptTo(ContentPolicyManager.class);
+        if (policyManager == null) {
+            LOG.trace("Policy manager is null. Unable to read policy property.");
+            return defaultValue;
+        }
+
+        ContentPolicy contentPolicy = policyManager.getPolicy(slingRequest.getResource());
+        if (contentPolicy == null) {
+            LOG.trace("Content policy is null. Unable to read policy property.");
+            return defaultValue;
+        }
+
+        return contentPolicy.getProperties().get(property, defaultValue);
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpLinkTransformer.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpLinkTransformer.java
@@ -15,10 +15,10 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.services.amp;
 
-import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.AMP_ONLY;
-import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.AMP_SELECTOR;
-import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.DOT;
-import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.NO_AMP;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpUtil.AMP_ONLY;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpUtil.AMP_SELECTOR;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpUtil.DOT;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpUtil.NO_AMP;
 
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
@@ -71,7 +71,7 @@ public class AmpLinkTransformer implements Transformer {
 
         slingRequest = processingContext.getRequest();
 
-        ampMode = AmpHelperUtil.getAmpMode(slingRequest);
+        ampMode = AmpUtil.getAmpMode(slingRequest);
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpLinkTransformer.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpLinkTransformer.java
@@ -1,0 +1,187 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.amp;
+
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.AMP_ONLY;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.AMP_SELECTOR;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.DOT;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.NO_AMP;
+
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.rewriter.ProcessingComponentConfiguration;
+import org.apache.sling.rewriter.ProcessingContext;
+import org.apache.sling.rewriter.Transformer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * Adds AMP specific link elements to the page head based on the request's selectors and the configured AMP mode.
+ */
+public class AmpLinkTransformer implements Transformer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AmpLinkTransformer.class);
+
+    private static final String AMP_REL = "amphtml";
+
+    private static final String HREF_ATTR = "href";
+
+    private static final String HTML = "html";
+
+    private static final String HTML_REL = "canonical";
+
+    private static final String LINK_ELEMENT = "link";
+
+    private static final String PAIRED_AMP = "pairedAmp";
+
+    private static final String REL_ATTR = "rel";
+
+    private String ampMode;
+
+    private ContentHandler contentHandler;
+
+    private SlingHttpServletRequest slingRequest;
+
+    @Override
+    public void init(ProcessingContext processingContext,
+                     ProcessingComponentConfiguration processingComponentConfiguration)
+        throws IOException {
+
+        slingRequest = processingContext.getRequest();
+
+        ampMode = AmpHelperUtil.getAmpMode(slingRequest);
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
+
+        // Append AMP sibling page link element.
+        if (ampMode != null && !ampMode.isEmpty() && !ampMode.equals(NO_AMP)) {
+
+            PageManager pageManager = slingRequest.getResourceResolver().adaptTo(PageManager.class);
+            if (pageManager != null) {
+
+                Page page = pageManager.getContainingPage(slingRequest.getResource());
+                if (page != null) {
+
+                    AttributesImpl attributes = getLinkAttributes(page.getPath());
+                    if (attributes != null) {
+                        contentHandler.startElement("", LINK_ELEMENT, LINK_ELEMENT, attributes);
+                    }
+                }
+            }
+        }
+
+        contentHandler.startElement(uri, localName, qName, atts);
+    }
+
+    /**
+     * Constructs the AMP link element attributes needed for the current AMP mode and request selectors.
+     * @param pagePath The path of the requested page.
+     * @return The AMP specific link element attributes.
+     */
+    private AttributesImpl getLinkAttributes(String pagePath) {
+
+        AttributesImpl attributes = new AttributesImpl();
+
+        boolean isAmpSelector = Arrays.asList(slingRequest.getRequestPathInfo().getSelectors()).contains(AMP_SELECTOR);
+
+        // Set the link element attributes based on the AMP mode and presence of the 'amp' request selector.
+        if (ampMode.equals(PAIRED_AMP)) {
+            if (isAmpSelector) {
+                attributes.addAttribute("", REL_ATTR, REL_ATTR, "", AMP_REL);
+                attributes.addAttribute("", HREF_ATTR, HREF_ATTR, "", pagePath + DOT + HTML);
+            } else {
+                attributes.addAttribute("", REL_ATTR, REL_ATTR, "", HTML_REL);
+                attributes.addAttribute("", HREF_ATTR, HREF_ATTR, "", pagePath + DOT + AMP_SELECTOR + DOT + HTML);
+            }
+        } else if (ampMode.equals(AMP_ONLY)) {
+            attributes.addAttribute("", REL_ATTR, REL_ATTR, "", AMP_REL);
+            attributes.addAttribute("", HREF_ATTR, HREF_ATTR, "", pagePath + DOT + AMP_SELECTOR + DOT + HTML);
+        } else {
+            return null;
+        }
+
+        return attributes;
+    }
+
+    @Override
+    public void setContentHandler(ContentHandler contentHandler) {
+        this.contentHandler = contentHandler;
+    }
+
+    @Override
+    public void dispose() { }
+
+    @Override
+    public void setDocumentLocator(Locator locator) {
+        contentHandler.setDocumentLocator(locator);
+    }
+
+    @Override
+    public void startDocument() throws SAXException {
+        contentHandler.startDocument();
+    }
+
+    @Override
+    public void endDocument() throws SAXException {
+        contentHandler.endDocument();
+    }
+
+    @Override
+    public void startPrefixMapping(String prefix, String uri) throws SAXException {
+        contentHandler.startPrefixMapping(prefix, uri);
+    }
+
+    @Override
+    public void endPrefixMapping(String prefix) throws SAXException {
+        contentHandler.endPrefixMapping(prefix);
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        contentHandler.endElement(uri, localName, qName);
+    }
+
+    @Override
+    public void characters(char[] ch, int start, int length) throws SAXException {
+        contentHandler.characters(ch, start, length);
+    }
+
+    @Override
+    public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
+        contentHandler.ignorableWhitespace(ch, start, length);
+    }
+
+    @Override
+    public void processingInstruction(String target, String data) throws SAXException {
+        contentHandler.processingInstruction(target, data);
+    }
+
+    @Override
+    public void skippedEntity(String name) throws SAXException {
+        contentHandler.skippedEntity(name);
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpModeForwardFilter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpModeForwardFilter.java
@@ -15,13 +15,16 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.services.amp;
 
-import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.AMP_ONLY;
-import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.AMP_SELECTOR;
-import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.DOT;
-import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.NO_AMP;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpUtil.AMP_ONLY;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpUtil.AMP_SELECTOR;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpUtil.DOT;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpUtil.NO_AMP;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.request.RequestDispatcherOptions;
+import org.apache.sling.api.servlets.HttpConstants;
+import org.apache.sling.api.servlets.ServletResolverConstants;
+import org.apache.sling.engine.EngineConstants;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,11 +45,11 @@ import java.io.IOException;
         service = {Filter.class},
         configurationPid = "com.adobe.cq.wcm.core.components.internal.services.amp.AmpModeForwardFilter",
         property = {
-                "sling.servlet.methods=GET",
-                "sling.servlet.extensions=amp.html",
-                "sling.filter.scope=request",
-                "sling.filter.pattern=/content/.*",
-                "service.ranking:Integer=1000",
+                ServletResolverConstants.SLING_SERVLET_METHODS + "=" + HttpConstants.METHOD_GET,
+                ServletResolverConstants.SLING_SERVLET_EXTENSIONS + "=amp.html",
+                EngineConstants.SLING_FILTER_SCOPE + "=" + EngineConstants.FILTER_SCOPE_REQUEST,
+                EngineConstants.SLING_FILTER_PATTERN + "=/content/.*",
+                "service.ranking:Integer=1000"
         }
 )
 public class AmpModeForwardFilter implements Filter {
@@ -69,7 +72,7 @@ public class AmpModeForwardFilter implements Filter {
 
         boolean hasAmpSelector = selectors.contains(AMP_SELECTOR);
 
-        String ampMode = AmpHelperUtil.getAmpMode(slingRequest);
+        String ampMode = AmpUtil.getAmpMode(slingRequest);
 
         if (hasAmpSelector && (ampMode.equals(NO_AMP) || ampMode.isEmpty())) {
 
@@ -128,8 +131,7 @@ public class AmpModeForwardFilter implements Filter {
     private boolean forward(SlingHttpServletRequest slingRequest, ServletResponse response,
                             RequestDispatcherOptions options) throws ServletException, IOException {
 
-        RequestDispatcher
-            dispatcher = slingRequest.getRequestDispatcher(slingRequest.getResource(), options);
+        RequestDispatcher dispatcher = slingRequest.getRequestDispatcher(slingRequest.getResource(), options);
         if (dispatcher != null) {
             dispatcher.forward(slingRequest, response);
             return true;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpModeForwardFilter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpModeForwardFilter.java
@@ -26,7 +26,13 @@ import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.*;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import java.io.IOException;
 
 /**
@@ -122,7 +128,8 @@ public class AmpModeForwardFilter implements Filter {
     private boolean forward(SlingHttpServletRequest slingRequest, ServletResponse response,
                             RequestDispatcherOptions options) throws ServletException, IOException {
 
-        RequestDispatcher dispatcher = slingRequest.getRequestDispatcher(slingRequest.getResource(), options);
+        RequestDispatcher
+            dispatcher = slingRequest.getRequestDispatcher(slingRequest.getResource(), options);
         if (dispatcher != null) {
             dispatcher.forward(slingRequest, response);
             return true;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpModeForwardFilter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpModeForwardFilter.java
@@ -1,0 +1,145 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.amp;
+
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.AMP_ONLY;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.AMP_SELECTOR;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.DOT;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.NO_AMP;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.request.RequestDispatcherOptions;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.*;
+import java.io.IOException;
+
+/**
+ * Forwards page requests based on the request's 'amp' selector and the page's AMP mode value.
+ */
+@Component(
+        service = {Filter.class},
+        configurationPid = "com.adobe.cq.wcm.core.components.internal.services.amp.AmpModeForwardFilter",
+        property = {
+                "sling.servlet.methods=GET",
+                "sling.servlet.extensions=amp.html",
+                "sling.filter.scope=request",
+                "sling.filter.pattern=/content/.*",
+                "service.ranking:Integer=1000",
+        }
+)
+public class AmpModeForwardFilter implements Filter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AmpModeForwardFilter.class);
+
+    /**
+     * @see Filter#doFilter(ServletRequest, ServletResponse, FilterChain)
+     */
+    public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
+            throws IOException, ServletException {
+
+        SlingHttpServletRequest slingRequest = (SlingHttpServletRequest) request;
+
+        // Read the full selector string from the request.
+        String selectors = slingRequest.getRequestPathInfo().getSelectorString();
+        if (selectors == null) {
+            selectors = "";
+        }
+
+        boolean hasAmpSelector = selectors.contains(AMP_SELECTOR);
+
+        String ampMode = AmpHelperUtil.getAmpMode(slingRequest);
+
+        if (hasAmpSelector && (ampMode.equals(NO_AMP) || ampMode.isEmpty())) {
+
+            // Remove the amp selector.
+            String newSelectors;
+            if (selectors.contains(DOT + AMP_SELECTOR)) {
+                newSelectors = selectors.replace(DOT + AMP_SELECTOR, "");
+            } else if (selectors.contains(AMP_SELECTOR + DOT)) {
+                newSelectors = selectors.replace(AMP_SELECTOR + DOT, "");
+            } else {
+                newSelectors = selectors.replace(AMP_SELECTOR, "");
+            }
+
+            // Apply the updated selectors.
+            RequestDispatcherOptions options = new RequestDispatcherOptions();
+            options.setReplaceSelectors(newSelectors);
+
+            if (forward(slingRequest, response, options)) {
+                return;
+            }
+        } else if (!hasAmpSelector && ampMode.equals(AMP_ONLY)) {
+
+            // Add the 'amp' selector to the dispatcher. Making sure to put it at the beginning of the selector list.
+            RequestDispatcherOptions options = new RequestDispatcherOptions();
+            if (!selectors.isEmpty()) {
+                options.setReplaceSelectors(AMP_SELECTOR + DOT + selectors);
+            } else {
+                options.setAddSelectors(AMP_SELECTOR);
+            }
+
+            if (forward(slingRequest, response, options)) {
+                return;
+            }
+        } else if (selectors.contains(DOT + AMP_SELECTOR)) {
+
+            // Move the amp selector to the front of the list of selectors.
+            RequestDispatcherOptions options = new RequestDispatcherOptions();
+            String newSelectors = selectors.replace(DOT + AMP_SELECTOR, "");
+            options.setReplaceSelectors(AMP_SELECTOR + DOT + newSelectors);
+
+            if (forward(slingRequest, response, options)) {
+                return;
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * Forwards the request using the provided dispatcher options.
+     * @param slingRequest The request to forward.
+     * @param response The response to forward.
+     * @param options The options to apply to the forward.
+     * @return If request forwarded successfully.
+     */
+    private boolean forward(SlingHttpServletRequest slingRequest, ServletResponse response,
+                            RequestDispatcherOptions options) throws ServletException, IOException {
+
+        RequestDispatcher dispatcher = slingRequest.getRequestDispatcher(slingRequest.getResource(), options);
+        if (dispatcher != null) {
+            dispatcher.forward(slingRequest, response);
+            return true;
+        }
+
+        LOG.debug("Request dispatcher is null. AMP mode forwarding aborted.");
+
+        return false;
+    }
+
+    /**
+     * @see Filter#init(FilterConfig)
+     */
+    public void init(final FilterConfig config) throws ServletException {}
+
+    /**
+     * @see Filter#destroy()
+     */
+    public void destroy() {}
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpTransformerFactory.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpTransformerFactory.java
@@ -1,0 +1,32 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.amp;
+
+import org.apache.sling.rewriter.Transformer;
+import org.apache.sling.rewriter.TransformerFactory;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Instantiates the transformers needed to manipulate and add AMP specific page markup.
+ */
+@Component(property = { "pipeline.type=amp-transformer" }, service = { TransformerFactory.class })
+public class AmpTransformerFactory implements TransformerFactory {
+
+    @Override
+    public Transformer createTransformer() {
+        return new AmpLinkTransformer();
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpUtil.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpUtil.java
@@ -27,9 +27,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Provides common value constants and methods used across AMP services.
  */
-class AmpHelperUtil {
+class AmpUtil {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AmpHelperUtil.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AmpUtil.class);
 
     private static final String AMP_MODE_PROP = "ampMode";
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ClientLibrary.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/ClientLibrary.java
@@ -1,0 +1,44 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.models;
+
+import org.osgi.annotation.versioning.ConsumerType;
+
+/**
+ * @since com.adobe.cq.wcm.core.components.models 12.11.0
+ */
+@ConsumerType
+public interface ClientLibrary {
+
+    /**
+     * Getter for the inline client library output based on the categories passed into the model.
+     *
+     * @return full client library output based on the passed categories.
+     */
+    default String getInline() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Getter for the inline client library output based on the component present on the page.
+     *
+     * @return The limited set of client library output.
+     */
+    default String getInlineLimited() {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.10.0")
+@Version("12.11.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/ClientLibraryAggregatorService.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/ClientLibraryAggregatorService.java
@@ -1,0 +1,31 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.services;
+
+import java.util.Set;
+
+import org.osgi.annotation.versioning.ConsumerType;
+
+/**
+ * @since com.adobe.cq.wcm.core.components.models 12.11.0
+ */
+@ConsumerType
+public interface ClientLibraryAggregatorService {
+
+    String getClientLibOutput(String baseCategory, String categoryString, String type);
+
+    String getClientLibOutput(String baseCategory, Set<String> resourceTypes, String type);
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/ClientLibraryAggregatorService.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/services/ClientLibraryAggregatorService.java
@@ -25,7 +25,10 @@ import org.osgi.annotation.versioning.ConsumerType;
 @ConsumerType
 public interface ClientLibraryAggregatorService {
 
-    String getClientLibOutput(String baseCategory, String categoryString, String type);
+    String getClientLibOutput(String categoryCsv, String type);
 
-    String getClientLibOutput(String baseCategory, Set<String> resourceTypes, String type);
+    String getClientLibOutput(String categoryCsv, String type, Set<String> resourceTypes, String primaryPath,
+                              String fallbackPath);
+
+    boolean isValidResourceType(String resourceType);
 }

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -57,6 +57,9 @@
                 <extensions>true</extensions>
                 <configuration>
                     <showImportPackageReport>false</showImportPackageReport>
+                    <properties>
+                        <acHandling>merge_preserve</acHandling>
+                    </properties>
                 </configuration>
             </plugin>
             <plugin>

--- a/config/src/content/META-INF/vault/filter.xml
+++ b/config/src/content/META-INF/vault/filter.xml
@@ -18,4 +18,7 @@
     <filter root="/apps/core/config"/>
     <filter root="/apps/core/wcm/config"/>
     <filter root="/apps/core/wcm/config.author"/>
+    <filter root="/apps">
+        <include pattern="/apps/rep:policy(/.*)?"/>
+    </filter>
 </workspaceFilter>

--- a/config/src/content/META-INF/vault/filter.xml
+++ b/config/src/content/META-INF/vault/filter.xml
@@ -15,6 +15,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <workspaceFilter version="1.0">
+    <filter root="/apps/core/config"/>
     <filter root="/apps/core/wcm/config"/>
     <filter root="/apps/core/wcm/config.author"/>
 </workspaceFilter>

--- a/config/src/content/META-INF/vault/filter.xml
+++ b/config/src/content/META-INF/vault/filter.xml
@@ -17,4 +17,7 @@
 <workspaceFilter version="1.0">
     <filter root="/apps/core/wcm/config"/>
     <filter root="/apps/core/wcm/config.author"/>
+    <filter root="/apps">
+        <include pattern="/apps/rep:policy(/.*)?"/>
+    </filter>
 </workspaceFilter>

--- a/config/src/content/jcr_root/apps/_rep_policy.xml
+++ b/config/src/content/jcr_root/apps/_rep_policy.xml
@@ -4,5 +4,9 @@
   <clientlibs-access
       jcr:primaryType="rep:GrantACE"
       rep:principalName="clientlibs-service"
-      rep:privileges="{Name}[jcr:read]"/>
+      rep:privileges="{Name}[jcr:read]">
+      <rep:restrictions
+          jcr:primaryType="rep:Restrictions"
+          rep:glob="*/clientlibs/*"/>
+  </clientlibs-access>
 </jcr:root>

--- a/config/src/content/jcr_root/apps/_rep_policy.xml
+++ b/config/src/content/jcr_root/apps/_rep_policy.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+          jcr:primaryType="rep:ACL">
+  <clientlibs-access
+      jcr:primaryType="rep:GrantACE"
+      rep:principalName="clientlibs-service"
+      rep:privileges="{Name}[jcr:read]"/>
+</jcr:root>

--- a/config/src/content/jcr_root/apps/core/config/rewriter/.content.xml
+++ b/config/src/content/jcr_root/apps/core/config/rewriter/.content.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder">
+    <amp
+        jcr:primaryType="nt:unstructured"
+        contentTypes="[text/html]"
+        enabled="{Boolean}true"
+        generatorType="htmlparser"
+        order="1"
+        paths="[/content]"
+        serializerType="htmlwriter"
+        transformerTypes="[amp-transformer]">
+        <generator-htmlparser
+            jcr:primaryType="nt:unstructured"
+            includeTags="[HEAD]"/>
+    </amp>
+</jcr:root>

--- a/config/src/content/jcr_root/apps/core/wcm/config/com.adobe.cq.wcm.core.components.internal.services.ClientLibraryAggregatorServiceImpl.xml
+++ b/config/src/content/jcr_root/apps/core/wcm/config/com.adobe.cq.wcm.core.components.internal.services.ClientLibraryAggregatorServiceImpl.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0" jcr:primaryType="sling:OsgiConfig"
+          getResourceTypeRegex="(?![A-Za-z]{2}:).*"/>

--- a/config/src/content/jcr_root/apps/core/wcm/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-clientlibservice.config
+++ b/config/src/content/jcr_root/apps/core/wcm/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-clientlibservice.config
@@ -1,0 +1,15 @@
+# Copyright 2019 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+user.mapping=["com.adobe.cq.core.wcm.components.core:component-clientlib-service\=clientlibs-service"]

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/amp.html
@@ -1,5 +1,5 @@
 <!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2016 Adobe Systems Incorporated
+  ~ Copyright 2019 Adobe Systems Incorporated
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/amp.html
@@ -1,0 +1,48 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2016 Adobe Systems Incorporated
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<div data-sly-use.image="com.adobe.cq.wcm.core.components.models.Image"
+     data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+     data-sly-test="${image.src}"
+     data-cmp-is="image"
+     data-cmp-lazy="${image.lazyEnabled}"
+     data-cmp-src="${image.srcUriTemplate ? image.srcUriTemplate : image.src}"
+     data-cmp-widths="${image.widths}"
+     data-asset="${image.fileReference}"
+     data-asset-id="${image.uuid}"
+     data-title="${image.title || image.alt}"
+     class="cmp-image${!wcmmode.disabled ? ' cq-dd-image' : ''}"
+     itemscope itemtype="http://schema.org/ImageObject">
+    <a data-sly-unwrap="${!image.link}"
+       class="cmp-image__link" href="${image.link}"
+       data-cmp-hook-image="link">
+        <noscript data-sly-unwrap="${!image.lazyEnabled && image.widths.length <= 1 && !image.areas}" data-cmp-hook-image="noscript">
+            <sly data-sly-test.usemap="${'{0}{1}' @ format=['#', resource.path]}"></sly>
+            <amp-img src="${image.src}" class="cmp-image__image" itemprop="contentUrl" data-cmp-hook-image="image"
+                     data-sly-attribute.usemap="${image.areas ? usemap : ''}"
+                     alt="${image.alt || true}" title="${image.displayPopupTitle && image.title}"/>
+            <map data-sly-test="${image.areas}"
+                 data-sly-list.area="${image.areas}"
+                 name="${resource.path}"
+                 data-cmp-hook-image="map">
+                <area shape="${area.shape}" coords="${area.coordinates}" href="${area.href}" target="${area.target}" alt="${area.alt}"
+                      data-cmp-hook-image="area" data-cmp-relcoords="${area.relativeCoordinates}">
+            </map>
+        </noscript>
+    </a>
+    <span class="cmp-image__title" itemprop="caption" data-sly-test="${!image.displayPopupTitle && image.title}">this is an AMP image</span>
+    <meta itemprop="caption" content="${image.title}" data-sly-test="${image.displayPopupTitle && image.title}">
+</div>
+<sly data-sly-call="${templates.placeholder @ isEmpty = !image.src, classAppend = 'cmp-image cq-dd-image'}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
@@ -117,7 +117,68 @@
                     <styletab
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="granite/ui/components/coral/foundation/include"
+                        margin="{Boolean}true"
                         path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_design/styletab"/>
+                    <amp
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Amp"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items
+                            jcr:primaryType="nt:unstructured"
+                            sling:hideChildren="[heading,well]">
+                            <mode
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                composite="{Boolean}false"
+                                fieldDescription="The mode in which you want AMP to be handled [add more description]"
+                                fieldLabel="Mode"
+                                name="./ampMode">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <noAmp
+                                        jcr:primaryType="nt:unstructured"
+                                        text="No Amp"
+                                        value="noAmp"/>
+                                    <pairedAmp
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Paired Amp"
+                                        value="pairedAmp"/>
+                                    <ampOnly
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Amp Only"
+                                        value="ampOnly"/>
+                                </items>
+                            </mode>
+                            <clientlibs
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                composite="{Boolean}false"
+                                fieldDescription="The CSS client library categories to load. Clientlibs selected will be added inline in the head of the document"
+                                fieldLabel="AMP Clientlibs">
+                                <field
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/container"
+                                    name="./ampClientlibs">
+                                    <items jcr:primaryType="nt:unstructured">
+                                        <category
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/autocomplete"
+                                            emptyText="AMP Clientlibs"
+                                            multiple="{Boolean}false"
+                                            name="./ampClientlibs"
+                                            required="{Boolean}false">
+                                            <datasource
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="core/wcm/components/commons/datasources/clientlibrarycategories/v1"/>
+                                            <options
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/autocomplete/list"/>
+                                        </category>
+                                    </items>
+                                </field>
+                            </clientlibs>
+                        </items>
+                    </amp>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
@@ -153,7 +153,7 @@
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
                                 composite="{Boolean}false"
-                                fieldDescription="The CSS client library categories to load. Clientlibs selected will be added inline in the head of the document"
+                                fieldDescription="The CSS base client library categories to load (not embedding components clientlibs). Clientlibs selected will be added inline in the head of the document along with  the css clientlibs of all the components on the page"
                                 fieldLabel="AMP Clientlibs">
                                 <field
                                     jcr:primaryType="nt:unstructured"

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
@@ -118,6 +118,44 @@
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="granite/ui/components/coral/foundation/include"
                         path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_design/styletab"/>
+                    <amp
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Amp"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items
+                            jcr:primaryType="nt:unstructured"
+                            sling:hideChildren="[heading,well]">
+                            <clientlibs
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                composite="{Boolean}false"
+                                fieldDescription="The CSS base client library categories to load (not embedding components clientlibs). Clientlibs selected will be added inline in the head of the document along with  the css clientlibs of all the components on the page"
+                                fieldLabel="AMP Base Clientlibs">
+                                <field
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/container"
+                                    name="./ampClientlibs">
+                                    <items jcr:primaryType="nt:unstructured">
+                                        <category
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/autocomplete"
+                                            emptyText="AMP Clientlibs"
+                                            multiple="{Boolean}false"
+                                            name="./ampClientlibs"
+                                            required="{Boolean}false">
+                                            <datasource
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="core/wcm/components/commons/datasources/clientlibrarycategories/v1"/>
+                                            <options
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/autocomplete/list"/>
+                                        </category>
+                                    </items>
+                                </field>
+                            </clientlibs>
+                        </items>
+                    </amp>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
@@ -112,27 +112,12 @@
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="granite/ui/components/foundation/form/autocomplete/list"/>
                             </appResourcesClientlib>
-                        </items>
-                    </properties>
-                    <styletab
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="granite/ui/components/coral/foundation/include"
-                        margin="{Boolean}true"
-                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_design/styletab"/>
-                    <amp
-                        jcr:primaryType="nt:unstructured"
-                        jcr:title="AMP"
-                        sling:resourceType="granite/ui/components/coral/foundation/container"
-                        margin="{Boolean}true">
-                        <items
-                            jcr:primaryType="nt:unstructured"
-                            sling:hideChildren="[heading,well]">
-                            <mode
+                            <ampmode
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                 composite="{Boolean}false"
                                 fieldDescription="The mode in which you want AMP to be handled. Paired AMP will serve AMP pages when the 'amp' selector is present. No AMP will never serve AMP pages. AMP only will always serve AMP pages."
-                                fieldLabel="Mode"
+                                fieldLabel="AMP Mode"
                                 name="./ampMode">
                                 <items jcr:primaryType="nt:unstructured">
                                     <noAmp
@@ -148,37 +133,14 @@
                                         text="AMP Only"
                                         value="ampOnly"/>
                                 </items>
-                            </mode>
-                            <clientlibs
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
-                                composite="{Boolean}false"
-                                fieldDescription="The CSS base client library categories to load (not embedding components clientlibs). Clientlibs selected will be added inline in the head of the document along with  the css clientlibs of all the components on the page"
-                                fieldLabel="AMP Clientlibs">
-                                <field
-                                    jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="granite/ui/components/coral/foundation/container"
-                                    name="./ampClientlibs">
-                                    <items jcr:primaryType="nt:unstructured">
-                                        <category
-                                            jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="granite/ui/components/coral/foundation/form/autocomplete"
-                                            emptyText="AMP Clientlibs"
-                                            multiple="{Boolean}false"
-                                            name="./ampClientlibs"
-                                            required="{Boolean}false">
-                                            <datasource
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="core/wcm/components/commons/datasources/clientlibrarycategories/v1"/>
-                                            <options
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/autocomplete/list"/>
-                                        </category>
-                                    </items>
-                                </field>
-                            </clientlibs>
+                            </ampmode>
                         </items>
-                    </amp>
+                    </properties>
+                    <styletab
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/include"
+                        margin="{Boolean}true"
+                        path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_design/styletab"/>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
@@ -118,44 +118,6 @@
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="granite/ui/components/coral/foundation/include"
                         path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_design/styletab"/>
-                    <amp
-                        jcr:primaryType="nt:unstructured"
-                        jcr:title="Amp"
-                        sling:resourceType="granite/ui/components/coral/foundation/container"
-                        margin="{Boolean}true">
-                        <items
-                            jcr:primaryType="nt:unstructured"
-                            sling:hideChildren="[heading,well]">
-                            <clientlibs
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
-                                composite="{Boolean}false"
-                                fieldDescription="The CSS base client library categories to load (not embedding components clientlibs). Clientlibs selected will be added inline in the head of the document along with  the css clientlibs of all the components on the page"
-                                fieldLabel="AMP Base Clientlibs">
-                                <field
-                                    jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="granite/ui/components/coral/foundation/container"
-                                    name="./ampClientlibs">
-                                    <items jcr:primaryType="nt:unstructured">
-                                        <category
-                                            jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="granite/ui/components/coral/foundation/form/autocomplete"
-                                            emptyText="AMP Clientlibs"
-                                            multiple="{Boolean}false"
-                                            name="./ampClientlibs"
-                                            required="{Boolean}false">
-                                            <datasource
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="core/wcm/components/commons/datasources/clientlibrarycategories/v1"/>
-                                            <options
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/autocomplete/list"/>
-                                        </category>
-                                    </items>
-                                </field>
-                            </clientlibs>
-                        </items>
-                    </amp>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
@@ -131,7 +131,7 @@
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                 composite="{Boolean}false"
-                                fieldDescription="The mode in which you want AMP to be handled [add more description]"
+                                fieldDescription="The mode in which you want AMP to be handled. Paired AMP will serve AMP pages when the 'amp' selector is present. No AMP will never serve AMP pages. AMP only will always serve AMP pages."
                                 fieldLabel="Mode"
                                 name="./ampMode">
                                 <items jcr:primaryType="nt:unstructured">

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
@@ -121,7 +121,7 @@
                         path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_design/styletab"/>
                     <amp
                         jcr:primaryType="nt:unstructured"
-                        jcr:title="Amp"
+                        jcr:title="AMP"
                         sling:resourceType="granite/ui/components/coral/foundation/container"
                         margin="{Boolean}true">
                         <items
@@ -137,15 +137,15 @@
                                 <items jcr:primaryType="nt:unstructured">
                                     <noAmp
                                         jcr:primaryType="nt:unstructured"
-                                        text="No Amp"
+                                        text="No AMP"
                                         value="noAmp"/>
                                     <pairedAmp
                                         jcr:primaryType="nt:unstructured"
-                                        text="Paired Amp"
+                                        text="Paired AMP"
                                         value="pairedAmp"/>
                                     <ampOnly
                                         jcr:primaryType="nt:unstructured"
-                                        text="Amp Only"
+                                        text="AMP Only"
                                         value="ampOnly"/>
                                 </items>
                             </mode>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_dialog/.content.xml
@@ -35,6 +35,52 @@
                 sling:resourceType="granite/ui/components/coral/foundation/tabs"
                 size="L">
                 <items jcr:primaryType="nt:unstructured">
+                    <amp
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="AMP"
+                        sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns">
+                        <items jcr:primaryType="nt:unstructured">
+                            <column
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <section
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="AMP Configuration"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <ampmode
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                composite="{Boolean}false"
+                                                fieldDescription="The mode in which you want AMP to be handled instead of what's defined in the page's content policy. Paired AMP will serve AMP pages when the 'amp' selector is present. No AMP will never serve AMP pages. AMP only will always serve AMP pages."
+                                                fieldLabel="AMP Mode"
+                                                name="./ampMode">
+                                                <items jcr:primaryType="nt:unstructured">
+                                                    <noOverride
+                                                        jcr:primaryType="nt:unstructured"
+                                                        text="No Override"
+                                                        value="noOverride"/>
+                                                    <noAmp
+                                                        jcr:primaryType="nt:unstructured"
+                                                        text="No Amp"
+                                                        value="noAmp"/>
+                                                    <pairedAmp
+                                                        jcr:primaryType="nt:unstructured"
+                                                        text="Paired Amp"
+                                                        value="pairedAmp"/>
+                                                    <ampOnly
+                                                        jcr:primaryType="nt:unstructured"
+                                                        text="Amp Only"
+                                                        value="ampOnly"/>
+                                                </items>
+                                            </ampmode>
+                                        </items>
+                                    </section>
+                                </items>
+                            </column>
+                        </items>
+                    </amp>
                     <socialmedia
                         cq:showOnCreate="{Boolean}true"
                         jcr:primaryType="nt:unstructured"

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/amp.html
@@ -22,7 +22,10 @@
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-    <style amp-custom=""></style>
+    <sly data-sly-use.clientlib="${'com.adobe.cq.wcm.core.components.models.ClientLibrary' @ type='css', primaryPath='clientlibs/amp', fallbackPath='clientlibs/site', categories='amp.base'}"/>
+    <style amp-custom>
+        ${clientlib.inlineLimited @ context = 'unsafe'}
+    </style>
 </head>
 <body class="${page.cssClassNames}">
 <h1>AMP page [placeholder]</h1>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/amp.html
@@ -1,5 +1,5 @@
 <!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2016 Adobe Systems Incorporated
+  ~ Copyright 2019 Adobe Systems Incorporated
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <!DOCTYPE HTML>
 <html amp data-sly-use.page="com.adobe.cq.wcm.core.components.models.Page" lang="${page.language}"
-      data-sly-use.head="head.html"
       data-sly-use.footer="footer.html"
       data-sly-use.redirect="redirect.html">
 <head data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html">
@@ -23,10 +22,10 @@
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-    <style amp-custom="">@import "newstyles.css"</style>
+    <style amp-custom=""></style>
 </head>
 <body class="${page.cssClassNames}">
-<h1>AMP page</h1>
+<h1>AMP page [placeholder]</h1>
 <sly data-sly-test="${!isRedirectPage}">
     <sly data-sly-include="body.socialmedia_begin.html"></sly>
     <sly data-sly-include="body.html"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/amp.html
@@ -1,0 +1,37 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2016 Adobe Systems Incorporated
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<!DOCTYPE HTML>
+<html amp data-sly-use.page="com.adobe.cq.wcm.core.components.models.Page" lang="${page.language}"
+      data-sly-use.head="head.html"
+      data-sly-use.footer="footer.html"
+      data-sly-use.redirect="redirect.html">
+<head data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html">
+    <meta charset="UTF-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <style amp-custom="">@import "newstyles.css"</style>
+</head>
+<body class="${page.cssClassNames}">
+<h1>AMP page</h1>
+<sly data-sly-test="${!isRedirectPage}">
+    <sly data-sly-include="body.socialmedia_begin.html"></sly>
+    <sly data-sly-include="body.html"></sly>
+    <sly data-sly-call="${footer.footer @ page = page}"></sly>
+    <sly data-sly-include="body.socialmedia_end.html"></sly>
+</sly>
+</body>
+</html>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/customheaderlibs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/customheaderlibs.html
@@ -17,7 +17,3 @@
 <!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ~ Create overlay of this file to include custom client libs in the page header
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<sly data-sly-use.clientlib="${'com.adobe.cq.wcm.core.components.models.ClientLibrary' @ type='css', primaryPath='clientlibs/amp', fallbackPath='clientlibs/site', categories='amp.base'}"/>
-<style>
-    ${clientlib.inlineLimited @ context = 'unsafe'}
-</style>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/customheaderlibs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/customheaderlibs.html
@@ -17,3 +17,7 @@
 <!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ~ Create overlay of this file to include custom client libs in the page header
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<sly data-sly-use.clientlib="${'com.adobe.cq.wcm.core.components.models.ClientLibrary' @ type='css'}"/>
+<style>
+    ${clientlib.inlineLimited @ context = 'unsafe'}
+</style>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/customheaderlibs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/customheaderlibs.html
@@ -17,7 +17,7 @@
 <!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ~ Create overlay of this file to include custom client libs in the page header
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<sly data-sly-use.clientlib="${'com.adobe.cq.wcm.core.components.models.ClientLibrary' @ type='css'}"/>
+<sly data-sly-use.clientlib="${'com.adobe.cq.wcm.core.components.models.ClientLibrary' @ type='css', primaryPath='clientlibs/amp', fallbackPath='clientlibs/site', categories='amp.base'}"/>
 <style>
     ${clientlib.inlineLimited @ context = 'unsafe'}
 </style>

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/amp.html
@@ -1,5 +1,5 @@
 <!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2016 Adobe Systems Incorporated
+  ~ Copyright 2019 Adobe Systems Incorporated
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/amp.html
@@ -1,0 +1,23 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2016 Adobe Systems Incorporated
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<div class="cmp-title"
+     data-sly-use.title="com.adobe.cq.wcm.core.components.models.Title"
+     data-sly-use.template="core/wcm/components/commons/v1/templates.html"
+     data-sly-test.text="${title.text}">
+    <h1 class="cmp-title__text" data-sly-element="${title.type}"><a data-sly-unwrap="${!title.linkURL || title.linkDisabled}" class="cmp-title__link" href="${title.linkURL}">this is an AMP title</a></h1>
+    <h6 class="cmp-title__text">${title.text}</h6>
+</div>
+<sly data-sly-call="${template.placeholder @ isEmpty=!text, classAppend='cmp-title'}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/clientlibs/amp/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/clientlibs/amp/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="[core.wcm.components.title.v2.amp]"/>

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/clientlibs/amp/css.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/clientlibs/amp/css.txt
@@ -1,0 +1,19 @@
+###############################################################################
+# Copyright 2017 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=css
+
+title.less

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/clientlibs/amp/css/title.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/clientlibs/amp/css/title.less
@@ -1,0 +1,17 @@
+/*
+ *  Copyright 2018 Adobe
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+.cmp-title__text {}

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/clientlibs/amp/css/title.less
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/clientlibs/amp/css/title.less
@@ -14,4 +14,6 @@
  *  limitations under the License.
  */
 
-.cmp-title__text {}
+.cmp-title__text {
+    display: flex;
+}


### PR DESCRIPTION
Laundry list:

- unit tests
- maybe more constants?
- line 98 in ClientLibraryAggregatorServiceImpl - decide how to actually name/define the `amp clientlib`
- performance around searching underneath the page. currently aggregates _all_ resource types (includes like nt:file), maybe a config to limit the search to certain resource types?
- line 61 and line 67 in ClientLibraryImpl need to be updated to pull the correct 'base clientlib'
- service user `clientlibs-service` may not have explicit permissions on the clientlibs needed - investigate
- line 78 in ClientLibraryAggregatorServiceImpl - maybe use htmlLibraryManager.isMinifyEnabled() instead of hardcoding the minify boolean 
- Javadoc
- not sure of the actual usage of passing clientlib categories into the sling model. it works fine and may be a useful feature but is not specifically necessary for this task. more for the usage of a static set of clientlibs to include inline.