### PR TITLE
AMP Parallel Delivery

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpHelperUtil.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpHelperUtil.java
@@ -1,0 +1,100 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.amp;
+
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.policies.ContentPolicy;
+import com.day.cq.wcm.api.policies.ContentPolicyManager;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides common value constants and methods used across AMP services.
+ */
+class AmpHelperUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AmpHelperUtil.class);
+
+    private static final String AMP_MODE_PROP = "ampMode";
+
+    private static final String NO_OVERRIDE = "noOverride";
+
+    static final String AMP_ONLY = "ampOnly";
+
+    static final String AMP_SELECTOR = "amp";
+
+    static final String DOT = ".";
+
+    static final String NO_AMP = "noAmp";
+
+    /**
+     * Retrieves the AMP mode value of the requested resource.
+     * @param slingRequest Request used to resolve the resource and AMP mode value from.
+     * @return The AMP mode value.
+     */
+    static String getAmpMode(@NotNull SlingHttpServletRequest slingRequest) {
+
+        PageManager pageManager = slingRequest.getResourceResolver().adaptTo(PageManager.class);
+
+        if (pageManager == null) {
+            LOG.debug("Can't resolve page manager. Falling back to content policy AMP mode.");
+            return getPolicyProperty(AMP_MODE_PROP, "", slingRequest);
+        }
+
+        Page page = pageManager.getContainingPage(slingRequest.getResource());
+
+        if (page != null) {
+
+            String ampMode = page.getProperties().get(AMP_MODE_PROP, "");
+
+            if (!ampMode.isEmpty() && !ampMode.equals(NO_OVERRIDE)) {
+                return ampMode;
+            }
+        }
+
+        return getPolicyProperty(AMP_MODE_PROP, "", slingRequest);
+    }
+
+    /**
+     * Retrieves the value of the given property from the request resource's content policy.
+     * @param property The name of the property to read.
+     * @param defaultValue The type hint and default value returned.
+     * @param slingRequest The request used to get the resource and its content policy.
+     * @param <T> The type of the property value expected.
+     * @return The value of the property of the resource's content policy. Returns null if fails to read the content
+     * policy.
+     */
+    private static <T> T getPolicyProperty(String property, T defaultValue,
+                                           @NotNull SlingHttpServletRequest slingRequest) {
+
+        ContentPolicyManager policyManager = slingRequest.getResourceResolver().adaptTo(ContentPolicyManager.class);
+        if (policyManager == null) {
+            LOG.trace("Policy manager is null. Unable to read policy property.");
+            return defaultValue;
+        }
+
+        ContentPolicy contentPolicy = policyManager.getPolicy(slingRequest.getResource());
+        if (contentPolicy == null) {
+            LOG.trace("Content policy is null. Unable to read policy property.");
+            return defaultValue;
+        }
+
+        return contentPolicy.getProperties().get(property, defaultValue);
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpLinkTransformer.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpLinkTransformer.java
@@ -1,0 +1,187 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.amp;
+
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.AMP_ONLY;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.AMP_SELECTOR;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.DOT;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.NO_AMP;
+
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.rewriter.ProcessingComponentConfiguration;
+import org.apache.sling.rewriter.ProcessingContext;
+import org.apache.sling.rewriter.Transformer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * Adds AMP specific link elements to the page head based on the request's selectors and the configured AMP mode.
+ */
+public class AmpLinkTransformer implements Transformer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AmpLinkTransformer.class);
+
+    private static final String AMP_REL = "amphtml";
+
+    private static final String HREF_ATTR = "href";
+
+    private static final String HTML = "html";
+
+    private static final String HTML_REL = "canonical";
+
+    private static final String LINK_ELEMENT = "link";
+
+    private static final String PAIRED_AMP = "pairedAmp";
+
+    private static final String REL_ATTR = "rel";
+
+    private String ampMode;
+
+    private ContentHandler contentHandler;
+
+    private SlingHttpServletRequest slingRequest;
+
+    @Override
+    public void init(ProcessingContext processingContext,
+                     ProcessingComponentConfiguration processingComponentConfiguration)
+        throws IOException {
+
+        slingRequest = processingContext.getRequest();
+
+        ampMode = AmpHelperUtil.getAmpMode(slingRequest);
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
+
+        // Append AMP sibling page link element.
+        if (ampMode != null && !ampMode.isEmpty() && !ampMode.equals(NO_AMP)) {
+
+            PageManager pageManager = slingRequest.getResourceResolver().adaptTo(PageManager.class);
+            if (pageManager != null) {
+
+                Page page = pageManager.getContainingPage(slingRequest.getResource());
+                if (page != null) {
+
+                    AttributesImpl attributes = getLinkAttributes(page.getPath());
+                    if (attributes != null) {
+                        contentHandler.startElement("", LINK_ELEMENT, LINK_ELEMENT, attributes);
+                    }
+                }
+            }
+        }
+
+        contentHandler.startElement(uri, localName, qName, atts);
+    }
+
+    /**
+     * Constructs the AMP link element attributes needed for the current AMP mode and request selectors.
+     * @param pagePath The path of the requested page.
+     * @return The AMP specific link element attributes.
+     */
+    private AttributesImpl getLinkAttributes(String pagePath) {
+
+        AttributesImpl attributes = new AttributesImpl();
+
+        boolean isAmpSelector = Arrays.asList(slingRequest.getRequestPathInfo().getSelectors()).contains(AMP_SELECTOR);
+
+        // Set the link element attributes based on the AMP mode and presence of the 'amp' request selector.
+        if (ampMode.equals(PAIRED_AMP)) {
+            if (isAmpSelector) {
+                attributes.addAttribute("", REL_ATTR, REL_ATTR, "", AMP_REL);
+                attributes.addAttribute("", HREF_ATTR, HREF_ATTR, "", pagePath + DOT + HTML);
+            } else {
+                attributes.addAttribute("", REL_ATTR, REL_ATTR, "", HTML_REL);
+                attributes.addAttribute("", HREF_ATTR, HREF_ATTR, "", pagePath + DOT + AMP_SELECTOR + DOT + HTML);
+            }
+        } else if (ampMode.equals(AMP_ONLY)) {
+            attributes.addAttribute("", REL_ATTR, REL_ATTR, "", AMP_REL);
+            attributes.addAttribute("", HREF_ATTR, HREF_ATTR, "", pagePath + DOT + AMP_SELECTOR + DOT + HTML);
+        } else {
+            return null;
+        }
+
+        return attributes;
+    }
+
+    @Override
+    public void setContentHandler(ContentHandler contentHandler) {
+        this.contentHandler = contentHandler;
+    }
+
+    @Override
+    public void dispose() { }
+
+    @Override
+    public void setDocumentLocator(Locator locator) {
+        contentHandler.setDocumentLocator(locator);
+    }
+
+    @Override
+    public void startDocument() throws SAXException {
+        contentHandler.startDocument();
+    }
+
+    @Override
+    public void endDocument() throws SAXException {
+        contentHandler.endDocument();
+    }
+
+    @Override
+    public void startPrefixMapping(String prefix, String uri) throws SAXException {
+        contentHandler.startPrefixMapping(prefix, uri);
+    }
+
+    @Override
+    public void endPrefixMapping(String prefix) throws SAXException {
+        contentHandler.endPrefixMapping(prefix);
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        contentHandler.endElement(uri, localName, qName);
+    }
+
+    @Override
+    public void characters(char[] ch, int start, int length) throws SAXException {
+        contentHandler.characters(ch, start, length);
+    }
+
+    @Override
+    public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
+        contentHandler.ignorableWhitespace(ch, start, length);
+    }
+
+    @Override
+    public void processingInstruction(String target, String data) throws SAXException {
+        contentHandler.processingInstruction(target, data);
+    }
+
+    @Override
+    public void skippedEntity(String name) throws SAXException {
+        contentHandler.skippedEntity(name);
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpModeForwardFilter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpModeForwardFilter.java
@@ -26,7 +26,13 @@ import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.*;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import java.io.IOException;
 
 /**
@@ -122,7 +128,8 @@ public class AmpModeForwardFilter implements Filter {
     private boolean forward(SlingHttpServletRequest slingRequest, ServletResponse response,
                             RequestDispatcherOptions options) throws ServletException, IOException {
 
-        RequestDispatcher dispatcher = slingRequest.getRequestDispatcher(slingRequest.getResource(), options);
+        RequestDispatcher
+            dispatcher = slingRequest.getRequestDispatcher(slingRequest.getResource(), options);
         if (dispatcher != null) {
             dispatcher.forward(slingRequest, response);
             return true;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpModeForwardFilter.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpModeForwardFilter.java
@@ -1,0 +1,145 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.amp;
+
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.AMP_ONLY;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.AMP_SELECTOR;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.DOT;
+import static com.adobe.cq.wcm.core.components.internal.services.amp.AmpHelperUtil.NO_AMP;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.request.RequestDispatcherOptions;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.*;
+import java.io.IOException;
+
+/**
+ * Forwards page requests based on the request's 'amp' selector and the page's AMP mode value.
+ */
+@Component(
+        service = {Filter.class},
+        configurationPid = "com.adobe.cq.wcm.core.components.internal.services.amp.AmpModeForwardFilter",
+        property = {
+                "sling.servlet.methods=GET",
+                "sling.servlet.extensions=amp.html",
+                "sling.filter.scope=request",
+                "sling.filter.pattern=/content/.*",
+                "service.ranking:Integer=1000",
+        }
+)
+public class AmpModeForwardFilter implements Filter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AmpModeForwardFilter.class);
+
+    /**
+     * @see Filter#doFilter(ServletRequest, ServletResponse, FilterChain)
+     */
+    public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
+            throws IOException, ServletException {
+
+        SlingHttpServletRequest slingRequest = (SlingHttpServletRequest) request;
+
+        // Read the full selector string from the request.
+        String selectors = slingRequest.getRequestPathInfo().getSelectorString();
+        if (selectors == null) {
+            selectors = "";
+        }
+
+        boolean hasAmpSelector = selectors.contains(AMP_SELECTOR);
+
+        String ampMode = AmpHelperUtil.getAmpMode(slingRequest);
+
+        if (hasAmpSelector && (ampMode.equals(NO_AMP) || ampMode.isEmpty())) {
+
+            // Remove the amp selector.
+            String newSelectors;
+            if (selectors.contains(DOT + AMP_SELECTOR)) {
+                newSelectors = selectors.replace(DOT + AMP_SELECTOR, "");
+            } else if (selectors.contains(AMP_SELECTOR + DOT)) {
+                newSelectors = selectors.replace(AMP_SELECTOR + DOT, "");
+            } else {
+                newSelectors = selectors.replace(AMP_SELECTOR, "");
+            }
+
+            // Apply the updated selectors.
+            RequestDispatcherOptions options = new RequestDispatcherOptions();
+            options.setReplaceSelectors(newSelectors);
+
+            if (forward(slingRequest, response, options)) {
+                return;
+            }
+        } else if (!hasAmpSelector && ampMode.equals(AMP_ONLY)) {
+
+            // Add the 'amp' selector to the dispatcher. Making sure to put it at the beginning of the selector list.
+            RequestDispatcherOptions options = new RequestDispatcherOptions();
+            if (!selectors.isEmpty()) {
+                options.setReplaceSelectors(AMP_SELECTOR + DOT + selectors);
+            } else {
+                options.setAddSelectors(AMP_SELECTOR);
+            }
+
+            if (forward(slingRequest, response, options)) {
+                return;
+            }
+        } else if (selectors.contains(DOT + AMP_SELECTOR)) {
+
+            // Move the amp selector to the front of the list of selectors.
+            RequestDispatcherOptions options = new RequestDispatcherOptions();
+            String newSelectors = selectors.replace(DOT + AMP_SELECTOR, "");
+            options.setReplaceSelectors(AMP_SELECTOR + DOT + newSelectors);
+
+            if (forward(slingRequest, response, options)) {
+                return;
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * Forwards the request using the provided dispatcher options.
+     * @param slingRequest The request to forward.
+     * @param response The response to forward.
+     * @param options The options to apply to the forward.
+     * @return If request forwarded successfully.
+     */
+    private boolean forward(SlingHttpServletRequest slingRequest, ServletResponse response,
+                            RequestDispatcherOptions options) throws ServletException, IOException {
+
+        RequestDispatcher dispatcher = slingRequest.getRequestDispatcher(slingRequest.getResource(), options);
+        if (dispatcher != null) {
+            dispatcher.forward(slingRequest, response);
+            return true;
+        }
+
+        LOG.debug("Request dispatcher is null. AMP mode forwarding aborted.");
+
+        return false;
+    }
+
+    /**
+     * @see Filter#init(FilterConfig)
+     */
+    public void init(final FilterConfig config) throws ServletException {}
+
+    /**
+     * @see Filter#destroy()
+     */
+    public void destroy() {}
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpTransformerFactory.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpTransformerFactory.java
@@ -1,0 +1,32 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.amp;
+
+import org.apache.sling.rewriter.Transformer;
+import org.apache.sling.rewriter.TransformerFactory;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Instantiates the transformers needed to manipulate and add AMP specific page markup.
+ */
+@Component(property = { "pipeline.type=amp-transformer" }, service = { TransformerFactory.class })
+public class AmpTransformerFactory implements TransformerFactory {
+
+    @Override
+    public Transformer createTransformer() {
+        return new AmpLinkTransformer();
+    }
+}

--- a/config/src/content/META-INF/vault/filter.xml
+++ b/config/src/content/META-INF/vault/filter.xml
@@ -15,6 +15,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <workspaceFilter version="1.0">
+    <filter root="/apps/core/config"/>
     <filter root="/apps/core/wcm/config"/>
     <filter root="/apps/core/wcm/config.author"/>
 </workspaceFilter>

--- a/config/src/content/jcr_root/apps/core/config/rewriter/.content.xml
+++ b/config/src/content/jcr_root/apps/core/config/rewriter/.content.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder">
+    <amp
+        jcr:primaryType="nt:unstructured"
+        contentTypes="[text/html]"
+        enabled="{Boolean}true"
+        generatorType="htmlparser"
+        order="1"
+        paths="[/content]"
+        serializerType="htmlwriter"
+        transformerTypes="[amp-transformer]">
+        <generator-htmlparser
+            jcr:primaryType="nt:unstructured"
+            includeTags="[HEAD]"/>
+    </amp>
+</jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/amp.html
@@ -1,5 +1,5 @@
 <!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2016 Adobe Systems Incorporated
+  ~ Copyright 2019 Adobe Systems Incorporated
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/amp.html
@@ -1,0 +1,48 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2016 Adobe Systems Incorporated
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<div data-sly-use.image="com.adobe.cq.wcm.core.components.models.Image"
+     data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+     data-sly-test="${image.src}"
+     data-cmp-is="image"
+     data-cmp-lazy="${image.lazyEnabled}"
+     data-cmp-src="${image.srcUriTemplate ? image.srcUriTemplate : image.src}"
+     data-cmp-widths="${image.widths}"
+     data-asset="${image.fileReference}"
+     data-asset-id="${image.uuid}"
+     data-title="${image.title || image.alt}"
+     class="cmp-image${!wcmmode.disabled ? ' cq-dd-image' : ''}"
+     itemscope itemtype="http://schema.org/ImageObject">
+    <a data-sly-unwrap="${!image.link}"
+       class="cmp-image__link" href="${image.link}"
+       data-cmp-hook-image="link">
+        <noscript data-sly-unwrap="${!image.lazyEnabled && image.widths.length <= 1 && !image.areas}" data-cmp-hook-image="noscript">
+            <sly data-sly-test.usemap="${'{0}{1}' @ format=['#', resource.path]}"></sly>
+            <amp-img src="${image.src}" class="cmp-image__image" itemprop="contentUrl" data-cmp-hook-image="image"
+                     data-sly-attribute.usemap="${image.areas ? usemap : ''}"
+                     alt="${image.alt || true}" title="${image.displayPopupTitle && image.title}"/>
+            <map data-sly-test="${image.areas}"
+                 data-sly-list.area="${image.areas}"
+                 name="${resource.path}"
+                 data-cmp-hook-image="map">
+                <area shape="${area.shape}" coords="${area.coordinates}" href="${area.href}" target="${area.target}" alt="${area.alt}"
+                      data-cmp-hook-image="area" data-cmp-relcoords="${area.relativeCoordinates}">
+            </map>
+        </noscript>
+    </a>
+    <span class="cmp-image__title" itemprop="caption" data-sly-test="${!image.displayPopupTitle && image.title}">this is an AMP image</span>
+    <meta itemprop="caption" content="${image.title}" data-sly-test="${image.displayPopupTitle && image.title}">
+</div>
+<sly data-sly-call="${templates.placeholder @ isEmpty = !image.src, classAppend = 'cmp-image cq-dd-image'}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
@@ -117,7 +117,68 @@
                     <styletab
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="granite/ui/components/coral/foundation/include"
+                        margin="{Boolean}true"
                         path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_design/styletab"/>
+                    <amp
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Amp"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items
+                            jcr:primaryType="nt:unstructured"
+                            sling:hideChildren="[heading,well]">
+                            <mode
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                composite="{Boolean}false"
+                                fieldDescription="The mode in which you want AMP to be handled [add more description]"
+                                fieldLabel="Mode"
+                                name="./ampMode">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <noAmp
+                                        jcr:primaryType="nt:unstructured"
+                                        text="No Amp"
+                                        value="noAmp"/>
+                                    <pairedAmp
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Paired Amp"
+                                        value="pairedAmp"/>
+                                    <ampOnly
+                                        jcr:primaryType="nt:unstructured"
+                                        text="Amp Only"
+                                        value="ampOnly"/>
+                                </items>
+                            </mode>
+                            <clientlibs
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                composite="{Boolean}false"
+                                fieldDescription="The CSS client library categories to load. Clientlibs selected will be added inline in the head of the document"
+                                fieldLabel="AMP Clientlibs">
+                                <field
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/container"
+                                    name="./ampClientlibs">
+                                    <items jcr:primaryType="nt:unstructured">
+                                        <category
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/autocomplete"
+                                            emptyText="AMP Clientlibs"
+                                            multiple="{Boolean}false"
+                                            name="./ampClientlibs"
+                                            required="{Boolean}false">
+                                            <datasource
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="core/wcm/components/commons/datasources/clientlibrarycategories/v1"/>
+                                            <options
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/autocomplete/list"/>
+                                        </category>
+                                    </items>
+                                </field>
+                            </clientlibs>
+                        </items>
+                    </amp>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
@@ -131,7 +131,7 @@
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                 composite="{Boolean}false"
-                                fieldDescription="The mode in which you want AMP to be handled [add more description]"
+                                fieldDescription="The mode in which you want AMP to be handled. Paired AMP will serve AMP pages when the 'amp' selector is present. No AMP will never serve AMP pages. AMP only will always serve AMP pages."
                                 fieldLabel="Mode"
                                 name="./ampMode">
                                 <items jcr:primaryType="nt:unstructured">

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_design_dialog/.content.xml
@@ -121,7 +121,7 @@
                         path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_design/styletab"/>
                     <amp
                         jcr:primaryType="nt:unstructured"
-                        jcr:title="Amp"
+                        jcr:title="AMP"
                         sling:resourceType="granite/ui/components/coral/foundation/container"
                         margin="{Boolean}true">
                         <items
@@ -137,15 +137,15 @@
                                 <items jcr:primaryType="nt:unstructured">
                                     <noAmp
                                         jcr:primaryType="nt:unstructured"
-                                        text="No Amp"
+                                        text="No AMP"
                                         value="noAmp"/>
                                     <pairedAmp
                                         jcr:primaryType="nt:unstructured"
-                                        text="Paired Amp"
+                                        text="Paired AMP"
                                         value="pairedAmp"/>
                                     <ampOnly
                                         jcr:primaryType="nt:unstructured"
-                                        text="Amp Only"
+                                        text="AMP Only"
                                         value="ampOnly"/>
                                 </items>
                             </mode>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/_cq_dialog/.content.xml
@@ -35,6 +35,52 @@
                 sling:resourceType="granite/ui/components/coral/foundation/tabs"
                 size="L">
                 <items jcr:primaryType="nt:unstructured">
+                    <amp
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="AMP"
+                        sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns">
+                        <items jcr:primaryType="nt:unstructured">
+                            <column
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/container">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <section
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="AMP Configuration"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <ampmode
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                                composite="{Boolean}false"
+                                                fieldDescription="The mode in which you want AMP to be handled instead of what's defined in the page's content policy. Paired AMP will serve AMP pages when the 'amp' selector is present. No AMP will never serve AMP pages. AMP only will always serve AMP pages."
+                                                fieldLabel="AMP Mode"
+                                                name="./ampMode">
+                                                <items jcr:primaryType="nt:unstructured">
+                                                    <noOverride
+                                                        jcr:primaryType="nt:unstructured"
+                                                        text="No Override"
+                                                        value="noOverride"/>
+                                                    <noAmp
+                                                        jcr:primaryType="nt:unstructured"
+                                                        text="No Amp"
+                                                        value="noAmp"/>
+                                                    <pairedAmp
+                                                        jcr:primaryType="nt:unstructured"
+                                                        text="Paired Amp"
+                                                        value="pairedAmp"/>
+                                                    <ampOnly
+                                                        jcr:primaryType="nt:unstructured"
+                                                        text="Amp Only"
+                                                        value="ampOnly"/>
+                                                </items>
+                                            </ampmode>
+                                        </items>
+                                    </section>
+                                </items>
+                            </column>
+                        </items>
+                    </amp>
                     <socialmedia
                         cq:showOnCreate="{Boolean}true"
                         jcr:primaryType="nt:unstructured"

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/amp.html
@@ -1,5 +1,5 @@
 <!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2016 Adobe Systems Incorporated
+  ~ Copyright 2019 Adobe Systems Incorporated
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <!DOCTYPE HTML>
 <html amp data-sly-use.page="com.adobe.cq.wcm.core.components.models.Page" lang="${page.language}"
-      data-sly-use.head="head.html"
       data-sly-use.footer="footer.html"
       data-sly-use.redirect="redirect.html">
 <head data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html">
@@ -23,10 +22,10 @@
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-    <style amp-custom="">@import "newstyles.css"</style>
+    <style amp-custom=""></style>
 </head>
 <body class="${page.cssClassNames}">
-<h1>AMP page</h1>
+<h1>AMP page [placeholder]</h1>
 <sly data-sly-test="${!isRedirectPage}">
     <sly data-sly-include="body.socialmedia_begin.html"></sly>
     <sly data-sly-include="body.html"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/amp.html
@@ -1,0 +1,37 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2016 Adobe Systems Incorporated
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<!DOCTYPE HTML>
+<html amp data-sly-use.page="com.adobe.cq.wcm.core.components.models.Page" lang="${page.language}"
+      data-sly-use.head="head.html"
+      data-sly-use.footer="footer.html"
+      data-sly-use.redirect="redirect.html">
+<head data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html">
+    <meta charset="UTF-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <style amp-custom="">@import "newstyles.css"</style>
+</head>
+<body class="${page.cssClassNames}">
+<h1>AMP page</h1>
+<sly data-sly-test="${!isRedirectPage}">
+    <sly data-sly-include="body.socialmedia_begin.html"></sly>
+    <sly data-sly-include="body.html"></sly>
+    <sly data-sly-call="${footer.footer @ page = page}"></sly>
+    <sly data-sly-include="body.socialmedia_end.html"></sly>
+</sly>
+</body>
+</html>

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/amp.html
@@ -1,5 +1,5 @@
 <!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2016 Adobe Systems Incorporated
+  ~ Copyright 2019 Adobe Systems Incorporated
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/amp.html
@@ -1,0 +1,23 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2016 Adobe Systems Incorporated
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<div class="cmp-title"
+     data-sly-use.title="com.adobe.cq.wcm.core.components.models.Title"
+     data-sly-use.template="core/wcm/components/commons/v1/templates.html"
+     data-sly-test.text="${title.text}">
+    <h1 class="cmp-title__text" data-sly-element="${title.type}"><a data-sly-unwrap="${!title.linkURL || title.linkDisabled}" class="cmp-title__link" href="${title.linkURL}">this is an AMP title</a></h1>
+    <h6 class="cmp-title__text">${title.text}</h6>
+</div>
+<sly data-sly-call="${template.placeholder @ isEmpty=!text, classAppend='cmp-title'}"></sly>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

This pull request implements parallel delivery of pages needed for AMP specific content. The functionality is driven via a combination of  a new `ampMode` page policy/property value and the presence of an `.amp` selector. The `ampMode` value can either be defined in the page policy or in the page properties. Page property `ampMode` values will take precedence over page policy values. Absence of any `ampMode` value will always return the non-AMP counterpart of the requested page regardless of the inclusion of an `.amp` selector. In the `pairedAmp` or `ampOnly` modes an [AMP specific link element](https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/?format=websites#required-markup) will be appended to the head via a sling transformer.
