### PR TITLE
Removed social begin and end inclusion in amp.html as it adds JS when…

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/amp.html
@@ -29,11 +29,9 @@
 </head>
 <body class="${page.cssClassNames}">
     <sly data-sly-test="${!isRedirectPage}">
-    <sly data-sly-include="body.socialmedia_begin.html"></sly>
     <sly data-sly-include="body.html"></sly>
     <!--/* TODO: decide if we want the footer in AMP or not */-->
     <!--/* TODO: How to handle cloudservices in AMP? */-->
-    <sly data-sly-include="body.socialmedia_end.html"></sly>
 </sly>
 </body>
 </html>


### PR DESCRIPTION
… sharing is enabled on the page

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | AMP-18
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
This PR fixes the amp page rendering when social sharing is turned on.