### PR TITLE
Feature/amp/amp 23 tabs

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
@@ -13,30 +13,38 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<div data-sly-use.tabs="com.adobe.cq.wcm.core.components.models.Tabs"
-     data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
-     class="cmp-tabs"
-     data-cmp-is="tabs">
-     <ol data-sly-test="${tabs.items && tabs.items.size > 0}"
-         data-sly-list.tab="${tabs.items}"
-         role="tablist"
-         class="cmp-tabs__tablist"
-         aria-label="${tabs.accessibilityLabel}"
-         aria-multiselectable="false">
-         <sly data-sly-test.isActive="${tab.name == tabs.activeItem}"/>
-         <li role="tab"
-             class="cmp-tabs__tab${isActive ? ' cmp-tabs__tab--active' : ''}"
-             tabindex="${isActive ? '0' : '-1'}"
-             data-cmp-hook-tabs="tab">${tab.title}
-         </li>
-     </ol>
-     <div data-sly-repeat.item="${tabs.items}"
-          data-sly-resource="${item.name @ decorationTagName='div'}"
-          role="tabpanel"
-          tabindex="0"
-          class="cmp-tabs__tabpanel${item.name == tabs.activeItem ? ' cmp-tabs__tabpanel--active' : ''}"
-          data-cmp-hook-tabs="tabpanel">
-     </div>
-     <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
-          data-sly-test="${(wcmmode.edit || wcmmode.preview) && tabs.items.size < 1}"></sly>
+  
+<div
+	data-sly-use.tabs="com.adobe.cq.wcm.core.components.models.Tabs"
+  data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+  class="cmp-tabs"
+  data-cmp-is="tabs">
+
+	<amp-selector data-sly-test="${tabs.items && tabs.items.size > 0}"
+		role="tablist"
+		data-sly-list.tab="${tabs.items}"
+		class="cmp-tabs__tablist tabs-with-flex"
+		aria-label="${tabs.accessibilityLabel}"
+		aria-multiselectable="false">
+		<sly data-sly-test.isActive="${tab.name == tabs.activeItem}"/>
+
+		<div role="tab"
+				 option
+				 id="tab-item-${tabList.index}"
+				 aria-controls="tab-panel-${tabList.index}"
+				 class="cmp-tabs__tab${isActive ? ' cmp-tabs__tab--active' : ''}"
+				 tabindex="${isActive ? '0' : '-1'}"
+				 data-cmp-hook-tabs="tab">${tab.title}</div>
+
+		<div id="tab-panel-${tabList.index}"
+				 aria-labelledby="tab-item-${tabList.index}"
+				 data-sly-resource="${tab.name @ decorationTagName='div'}"
+				 role="tabpanel"
+				 tabindex="0"
+				 class="cmp-tabs__tabpanel${tab.name == tabs.activeItem ? ' cmp-tabs__tabpanel--active' : ''}"
+				 data-cmp-hook-tabs="tabpanel"></div>
+		<sly
+		data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
+		data-sly-test="${(wcmmode.edit || wcmmode.preview) && tabs.items.size < 1}"></sly>         
+	</amp-selector>
 </div>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
@@ -15,39 +15,39 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
   
 <div data-sly-use.tabs="com.adobe.cq.wcm.core.components.models.Tabs"
-  	 data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
-  	 class="cmp-tabs"
-	 data-cmp-is="tabs">
+     data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+     class="cmp-tabs"
+     data-cmp-is="tabs">
 
-	<amp-selector data-sly-test="${tabs.items && tabs.items.size > 0}"
-		role="tablist"
-		data-sly-list.tab="${tabs.items}"
-		class="cmp-tabs__tablist tabs-with-flex"
-		aria-label="${tabs.accessibilityLabel}"
-		aria-multiselectable="false">
-		<sly data-sly-test.isActive="${tab.name == tabs.activeItem}"/>
+    <amp-selector data-sly-test="${tabs.items && tabs.items.size > 0}"
+        role="tablist"
+        data-sly-list.tab="${tabs.items}"
+        class="cmp-tabs__tablist tabs-with-flex"
+        aria-label="${tabs.accessibilityLabel}"
+        aria-multiselectable="false">
+        <sly data-sly-test.isActive="${tab.name == tabs.activeItem}"/>
 
-		<div role="tab"
-			 option
-			 id="tab-item-${tabList.index}"
-			 aria-controls="tab-panel-${tabList.index}"
-			 class="cmp-tabs__tab"
-			 data-sly-attribute.selected=${isActive}
-			 tabindex="${isActive ? '0' : '-1'}"
-			 data-cmp-hook-tabs="tab">
-			 ${tab.title}
-		</div>
+        <div role="tab"
+             option
+             id="tab-item-${tabList.index}"
+             aria-controls="tab-panel-${tabList.index}"
+             class="cmp-tabs__tab"
+             data-sly-attribute.selected=${isActive}
+             tabindex="${isActive ? '0' : '-1'}"
+             data-cmp-hook-tabs="tab">
+             ${tab.title}
+        </div>
 
-		<div id="tab-panel-${tabList.index}"
-			 aria-labelledby="tab-item-${tabList.index}"
-			 data-sly-resource="${tab.name @ decorationTagName='div'}"
-			 role="tabpanel"
-			 tabindex="0"
-			 class="cmp-tabs__tabpanel${tab.name == tabs.activeItem ? ' cmp-tabs__tabpanel--active' : ''}"
-			 data-cmp-hook-tabs="tabpanel"></div>
+        <div id="tab-panel-${tabList.index}"
+             aria-labelledby="tab-item-${tabList.index}"
+             data-sly-resource="${tab.name @ decorationTagName='div'}"
+             role="tabpanel"
+             tabindex="0"
+             class="cmp-tabs__tabpanel${tab.name == tabs.activeItem ? ' cmp-tabs__tabpanel--active' : ''}"
+             data-cmp-hook-tabs="tabpanel"></div>
 
-		<sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
-			 data-sly-test="${(wcmmode.edit || wcmmode.preview) && tabs.items.size < 1}">
-		</sly>         
-	</amp-selector>
+        <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
+             data-sly-test="${(wcmmode.edit || wcmmode.preview) && tabs.items.size < 1}">
+        </sly>         
+    </amp-selector>
 </div>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
@@ -14,11 +14,10 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
   
-<div
-	data-sly-use.tabs="com.adobe.cq.wcm.core.components.models.Tabs"
-  data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
-  class="cmp-tabs"
-  data-cmp-is="tabs">
+<div data-sly-use.tabs="com.adobe.cq.wcm.core.components.models.Tabs"
+  	 data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+  	 class="cmp-tabs"
+	 data-cmp-is="tabs">
 
 	<amp-selector data-sly-test="${tabs.items && tabs.items.size > 0}"
 		role="tablist"
@@ -29,22 +28,25 @@
 		<sly data-sly-test.isActive="${tab.name == tabs.activeItem}"/>
 
 		<div role="tab"
-				 option
-				 id="tab-item-${tabList.index}"
-				 aria-controls="tab-panel-${tabList.index}"
-				 class="cmp-tabs__tab${isActive ? ' cmp-tabs__tab--active' : ''}"
-				 tabindex="${isActive ? '0' : '-1'}"
-				 data-cmp-hook-tabs="tab">${tab.title}</div>
+			 option
+			 id="tab-item-${tabList.index}"
+			 aria-controls="tab-panel-${tabList.index}"
+			 class="cmp-tabs__tab${isActive ? ' cmp-tabs__tab--active' : ''}"
+			 tabindex="${isActive ? '0' : '-1'}"
+			 data-cmp-hook-tabs="tab">
+			 ${tab.title}
+		</div>
 
 		<div id="tab-panel-${tabList.index}"
-				 aria-labelledby="tab-item-${tabList.index}"
-				 data-sly-resource="${tab.name @ decorationTagName='div'}"
-				 role="tabpanel"
-				 tabindex="0"
-				 class="cmp-tabs__tabpanel${tab.name == tabs.activeItem ? ' cmp-tabs__tabpanel--active' : ''}"
-				 data-cmp-hook-tabs="tabpanel"></div>
-		<sly
-		data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
-		data-sly-test="${(wcmmode.edit || wcmmode.preview) && tabs.items.size < 1}"></sly>         
+			 aria-labelledby="tab-item-${tabList.index}"
+			 data-sly-resource="${tab.name @ decorationTagName='div'}"
+			 role="tabpanel"
+			 tabindex="0"
+			 class="cmp-tabs__tabpanel${tab.name == tabs.activeItem ? ' cmp-tabs__tabpanel--active' : ''}"
+			 data-cmp-hook-tabs="tabpanel"></div>
+
+		<sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
+			 data-sly-test="${(wcmmode.edit || wcmmode.preview) && tabs.items.size < 1}">
+		</sly>         
 	</amp-selector>
 </div>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
@@ -1,5 +1,5 @@
 <!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2018 Adobe
+  ~ Copyright 2019 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
@@ -31,7 +31,8 @@
 			 option
 			 id="tab-item-${tabList.index}"
 			 aria-controls="tab-panel-${tabList.index}"
-			 class="cmp-tabs__tab${isActive ? ' cmp-tabs__tab--active' : ''}"
+			 class="cmp-tabs__tab"
+			 data-sly-attribute.selected=${isActive}
 			 tabindex="${isActive ? '0' : '-1'}"
 			 data-cmp-hook-tabs="tab">
 			 ${tab.title}

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
@@ -1,0 +1,42 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2018 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+<div data-sly-use.tabs="com.adobe.cq.wcm.core.components.models.Tabs"
+     data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+     class="cmp-tabs"
+     data-cmp-is="tabs">
+     <ol data-sly-test="${tabs.items && tabs.items.size > 0}"
+         data-sly-list.tab="${tabs.items}"
+         role="tablist"
+         class="cmp-tabs__tablist"
+         aria-label="${tabs.accessibilityLabel}"
+         aria-multiselectable="false">
+         <sly data-sly-test.isActive="${tab.name == tabs.activeItem}"/>
+         <li role="tab"
+             class="cmp-tabs__tab${isActive ? ' cmp-tabs__tab--active' : ''}"
+             tabindex="${isActive ? '0' : '-1'}"
+             data-cmp-hook-tabs="tab">${tab.title}
+         </li>
+     </ol>
+     <div data-sly-repeat.item="${tabs.items}"
+          data-sly-resource="${item.name @ decorationTagName='div'}"
+          role="tabpanel"
+          tabindex="0"
+          class="cmp-tabs__tabpanel${item.name == tabs.activeItem ? ' cmp-tabs__tabpanel--active' : ''}"
+          data-cmp-hook-tabs="tabpanel">
+     </div>
+     <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
+          data-sly-test="${(wcmmode.edit || wcmmode.preview) && tabs.items.size < 1}"></sly>
+</div>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/customheadlibs.amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/customheadlibs.amp.html
@@ -1,0 +1,16 @@
+<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2018 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
+  <script async custom-element="amp-selector" src="https://cdn.ampproject.org/v0/amp-selector-0.1.js"></script>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/customheadlibs.amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/customheadlibs.amp.html
@@ -1,5 +1,5 @@
 <!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright 2018 Adobe
+  ~ Copyright 2019 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/.content.xml
+++ b/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/.content.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2019 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/amp/.content.xml
+++ b/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/amp/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
-    categories="[core.wcm.components.tabs.v1.amp]"/>
+    categories="[core.wcm.components.tabs.v1]"/>

--- a/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/amp/.content.xml
+++ b/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/amp/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
-    categories="[core.wcm.components.tabs.v1]"/>
+    categories="[core.wcm.components.tabs.v1.amp]"/>

--- a/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/amp/.content.xml
+++ b/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/amp/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    allowProxy="{Boolean}true"
+    categories="[core.wcm.components.tabs.v1]"/>

--- a/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/amp/css.txt
+++ b/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/amp/css.txt
@@ -1,0 +1,19 @@
+###############################################################################
+# Copyright 2019 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=css
+
+tabs.less

--- a/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/amp/css/tabs.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/amp/css/tabs.less
@@ -1,0 +1,15 @@
+/*
+ *  Copyright 2019 Adobe
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */

--- a/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/amp/css/tabs.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/amp/css/tabs.less
@@ -13,3 +13,58 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+ 
+@space-1: .5rem;
+@space-4: 2rem;
+ 
+amp-selector[role=tablist].tabs-with-flex {
+    display: flex;
+    flex-wrap: wrap;
+}
+amp-selector[role=tablist].tabs-with-flex [role=tab] {
+    flex-grow: 1;
+    text-align: center;
+    padding: var(@space-1);
+}
+
+amp-selector[role=tablist].tabs-with-flex [role=tabpanel] {
+    display: none;
+    width: 100%;
+    order: 1;
+    padding: var(@space-4);
+}
+amp-selector[role=tablist].tabs-with-flex [role=tab][selected] + [role=tabpanel] {
+    display: block;
+}
+
+amp-selector[role=tablist].tabs-with-selector {
+    display: flex;
+}
+
+amp-selector[role=tablist].tabs-with-selector [role=tab][selected] {
+    outline: none;
+}
+
+amp-selector[role=tablist].tabs-with-selector {
+    display: flex;
+}
+
+amp-selector[role=tablist].tabs-with-selector [role=tab] {
+    width: 100%;
+    text-align: center;
+    padding: var(@space-1);
+}
+
+amp-selector.tabpanels [role=tabpanel] {
+    display: none;
+    padding: var(@space-4);
+}
+
+amp-selector.tabpanels [role=tabpanel][selected] {
+    outline: none;
+    display: block;
+}
+
+amp-selector[role=tablist] [role=tab][selected] + [role=tabpanel] {
+    display: block;
+}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes AMP-23` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | No
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
This utilizes the AMP selector component to recreate the Tabs Core Component functionality. Unfortunaly AMP **does not** allow `<amp-selector>`s within other `<amp-selector>`s, so the "Nested" example in the [Tabs Library Example page](http://localhost:4502/content/core-components-examples/library/tabs.amp.html) will appear to work, but will not output valid AMP markup. This is specific to the "Nested" component example. The best way to test this is to recreate the component on the amp.html page. I do not foresee a way to support the "Nested" functionality within AMP. But the rest of the features should work as expected.