### PR TITLE
Feature/amp/amp 41 unit tests reach coverage

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibraryImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibraryImpl.java
@@ -50,19 +50,19 @@ public class ClientLibraryImpl implements ClientLibrary {
     private ClientLibraryAggregatorService aggregatorService;
 
     @Inject
-    private String categories;
+    protected String categories;
 
     @ScriptVariable
     private Page currentPage;
 
     @Inject
-    private String fallbackPath;
+    protected String fallbackPath;
 
     @Inject
-    private String primaryPath;
+    protected String primaryPath;
 
     @Inject
-    private String type;
+    protected String type;
 
     private String inline;
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImpl.java
@@ -62,10 +62,10 @@ public class ClientLibraryAggregatorServiceImpl implements ClientLibraryAggregat
     }
 
     @Reference
-    protected HtmlLibraryManager htmlLibraryManager;
+    private HtmlLibraryManager htmlLibraryManager;
 
     @Reference
-    protected ResourceResolverFactory resolverFactory;
+    private ResourceResolverFactory resolverFactory;
 
     private Cfg cfg;
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImpl.java
@@ -62,10 +62,10 @@ public class ClientLibraryAggregatorServiceImpl implements ClientLibraryAggregat
     }
 
     @Reference
-    private HtmlLibraryManager htmlLibraryManager;
+    protected HtmlLibraryManager htmlLibraryManager;
 
     @Reference
-    private ResourceResolverFactory resolverFactory;
+    protected ResourceResolverFactory resolverFactory;
 
     private Cfg cfg;
 
@@ -77,6 +77,20 @@ public class ClientLibraryAggregatorServiceImpl implements ClientLibraryAggregat
     @Modified
     protected void activate(Cfg cfg) {
         this.cfg = cfg;
+    }
+
+    protected String[] getClientLibArrayCategories(String categoryCsv) {
+      String[] categories;
+      if (categoryCsv.contains(",")) {
+          categories = categoryCsv.split(",");
+      } else {
+          categories = new String[] {categoryCsv};
+      }
+      return categories;
+    }
+
+    protected LibraryType getClientLibType(String type) {
+      return libraryTypeMap.get(type);
     }
 
     /**
@@ -98,15 +112,10 @@ public class ClientLibraryAggregatorServiceImpl implements ClientLibraryAggregat
         }
 
         // Parse the array of categories from the comma delimited category string.
-        String[] categories;
-        if (categoryCsv.contains(",")) {
-            categories = categoryCsv.split(",");
-        } else {
-            categories = new String[] {categoryCsv};
-        }
+        String[] categories = getClientLibArrayCategories(categoryCsv);
 
         // Retrieve the clientlibs of the categories of the specified type.
-        LibraryType libraryType = libraryTypeMap.get(type);
+        LibraryType libraryType = getClientLibType(type);
         Collection<ClientLibrary> libraries = htmlLibraryManager.getLibraries(categories, libraryType, false, true);
 
         // Iterate through the clientlibs and aggregate their content.
@@ -198,6 +207,7 @@ public class ClientLibraryAggregatorServiceImpl implements ClientLibraryAggregat
         return cfg.getResourceTypeRegex();
     }
 
+    @Override
     public ResourceResolver getClientlibResourceResolver() throws LoginException {
         return resolverFactory.getServiceResourceResolver(
             Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, Utils.CLIENTLIB_SUBSERVICE));
@@ -215,4 +225,3 @@ public class ClientLibraryAggregatorServiceImpl implements ClientLibraryAggregat
         String getResourceTypeRegex();
     }
 }
-

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpTransformer.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpTransformer.java
@@ -230,7 +230,6 @@ public class AmpTransformer implements Transformer {
         Resource resource = Utils.resolveResource(resolver, resourceType);
         if (resource == null) {
             LOG.debug("Can't access resource from resource type {}.", resourceType);
-            System.out.println("Nothing for " + resourceType);
             return null;
         }
         // Get resource superType path from the resource type.

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpTransformerFactory.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpTransformerFactory.java
@@ -60,6 +60,14 @@ public class AmpTransformerFactory implements TransformerFactory {
         this.resolverFactory = resolverFactory;
     }
 
+    public AmpTransformerFactory.Cfg getCfg() {
+        return this.cfg;
+    }
+
+    public ResourceResolverFactory getResolverFactory() {
+        return this.resolverFactory;
+    }
+
     @ObjectClassDefinition(name = "AMP Transformer Factory")
     public @interface Cfg {
 

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/UtilsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/UtilsTest.java
@@ -16,6 +16,7 @@
 package com.adobe.cq.wcm.core.components.internal;
 
 import org.mockito.Mockito;
+import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,8 +72,7 @@ public class UtilsTest {
     public void resolveResource_pathStartsWithSlash() {
         this.pathMock = "/fake/path/for/testing";
 
-        Mockito
-         .when(this.resourceResolverMock.getResource(this.pathMock))
+        when(this.resourceResolverMock.getResource(this.pathMock))
          .thenReturn(this.resourceMock);
 
         assertEquals(this.resourceMock, Utils.resolveResource(this.resourceResolverMock, this.pathMock));
@@ -83,12 +83,9 @@ public class UtilsTest {
         this.pathMock = "fake/path/for/testing";
         this.searchPathMock = new String[] { "/base/fake/path" };
 
-        Mockito
-         .when(this.resourceResolverMock.getSearchPath())
+        when(this.resourceResolverMock.getSearchPath())
          .thenReturn(this.searchPathMock);
-
-        Mockito
-         .when(this.resourceResolverMock.getResource(this.searchPathMock[0] + this.pathMock))
+        when(this.resourceResolverMock.getResource(this.searchPathMock[0] + this.pathMock))
          .thenReturn(null);
 
         assertEquals(null, Utils.resolveResource(this.resourceResolverMock, this.pathMock));
@@ -99,12 +96,9 @@ public class UtilsTest {
         this.pathMock = "fake/path/for/testing";
         this.searchPathMock = new String[] { "/base/fake/path" };
 
-        Mockito
-         .when(this.resourceResolverMock.getSearchPath())
+        when(this.resourceResolverMock.getSearchPath())
          .thenReturn(this.searchPathMock);
-
-        Mockito
-         .when(this.resourceResolverMock.getResource(this.searchPathMock[0] + this.pathMock))
+        when(this.resourceResolverMock.getResource(this.searchPathMock[0] + this.pathMock))
          .thenReturn(this.resourceMock);
 
         assertEquals(this.resourceMock, Utils.resolveResource(this.resourceResolverMock, this.pathMock));
@@ -117,8 +111,7 @@ public class UtilsTest {
         this.resourceTypesMock.add("dummyType");
         this.resourceTypesMock.add("fakeType");
 
-        Mockito
-         .when(this.pageMock.getTemplate())
+        when(this.pageMock.getTemplate())
          .thenReturn(null);
 
         assertEquals(this.resourceTypesMock, Utils.getTemplateResourceTypes(this.pageMock, this.resourceTypeRegexMock, this.resourceResolverMock, this.resourceTypesMock));
@@ -132,16 +125,11 @@ public class UtilsTest {
         this.resourceTypesMock.add("dummyType");
         this.resourceTypesMock.add("fakeType");
 
-        Mockito
-         .when(this.pageMock.getTemplate())
+        when(this.pageMock.getTemplate())
          .thenReturn(this.templateMock);
-
-        Mockito
-         .when(this.templateMock.getPath())
+        when(this.templateMock.getPath())
          .thenReturn(this.pathMock);
-
-        Mockito
-         .when(this.resourceResolverMock.getResource(this.pathMock + AllowedComponentList.STRUCTURE_JCR_CONTENT))
+        when(this.resourceResolverMock.getResource(this.pathMock + AllowedComponentList.STRUCTURE_JCR_CONTENT))
          .thenReturn(null);
 
         assertEquals(this.resourceTypesMock, Utils.getTemplateResourceTypes(this.pageMock, this.resourceTypeRegexMock, this.resourceResolverMock, this.resourceTypesMock));
@@ -158,8 +146,7 @@ public class UtilsTest {
 
         this.resourceTypesMock.add("dummyType");
 
-        Mockito
-         .when(this.resourceMock.getResourceType())
+        when(this.resourceMock.getResourceType())
          .thenReturn("fakeType");
 
         Set<String> resourceTypesResult = new HashSet<String>();
@@ -174,8 +161,7 @@ public class UtilsTest {
     public void getURLExtended_pageNull() {
         this.pathMock = "fake/path/for/testing";
 
-        Mockito
-         .when(this.pageManagerMock.getPage(this.pathMock))
+        when(this.pageManagerMock.getPage(this.pathMock))
          .thenReturn(null);
 
         assertEquals(this.pathMock, Utils.getURL(this.slingHttpServletRequestMock, this.pageManagerMock, this.pathMock));
@@ -183,16 +169,11 @@ public class UtilsTest {
 
     @Test
     public void getURLExtended_vanityUrlEmpty() {
-        Mockito
-         .when(this.pageMock.getVanityUrl())
+        when(this.pageMock.getVanityUrl())
          .thenReturn("");
-
-        Mockito
-         .when(this.pageMock.getPath())
+        when(this.pageMock.getPath())
          .thenReturn("testPage");
-
-        Mockito
-         .when(this.slingHttpServletRequestMock.getContextPath())
+        when(this.slingHttpServletRequestMock.getContextPath())
          .thenReturn("/fake/path/for/testing/");
 
         assertEquals("/fake/path/for/testing/testPage.html", Utils.getURL(this.slingHttpServletRequestMock, this.pageMock));
@@ -200,12 +181,9 @@ public class UtilsTest {
 
     @Test
     public void getURLExtended_vanityUrlNotEmpty() {
-        Mockito
-         .when(this.pageMock.getVanityUrl())
+        when(this.pageMock.getVanityUrl())
          .thenReturn("testPage.html");
-
-        Mockito
-         .when(this.slingHttpServletRequestMock.getContextPath())
+        when(this.slingHttpServletRequestMock.getContextPath())
          .thenReturn("/fake/path/for/testing/");
 
         assertEquals("/fake/path/for/testing/testPage.html", Utils.getURL(this.slingHttpServletRequestMock, this.pageMock));

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/UtilsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/UtilsTest.java
@@ -15,7 +15,9 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal;
 
-import org.mockito.Mockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.MockitoAnnotations.initMocks;
 import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
@@ -37,114 +39,106 @@ import java.util.Set;
 import java.util.HashSet;
 
 public class UtilsTest {
-    // resolveResource method
+    @Mock
     ResourceResolver resourceResolverMock;
+    @Mock
     Resource resourceMock;
-    String pathMock;
-    String[] searchPathMock;
-
-    // getTemplateResourceTypes method
+    @Mock
     Page pageMock;
+    @Mock
     Template templateMock;
-    String resourceTypeRegexMock;
-    Set<String> resourceTypesMock;
-
-    // getURL method
+    @Mock
     SlingHttpServletRequest slingHttpServletRequestMock;
+    @Mock
     PageManager pageManagerMock;
+
+    String pathSample;
+    String[] searchPathSample;
+    String resourceTypeRegexSample;
+    Set<String> resourceTypesSample;
 
     @BeforeEach
     void setUp() {
-        // resolveResource method
-        this.resourceResolverMock = Mockito.mock(ResourceResolver.class);
-        this.resourceMock = Mockito.mock(Resource.class);
-
-        // getTemplateResourceTypes method
-        this.pageMock = Mockito.mock(Page.class);
-        this.templateMock = Mockito.mock(Template.class);
-
-        // getURL method
-        this.slingHttpServletRequestMock = Mockito.mock(SlingHttpServletRequest.class);
-        this.pageManagerMock = Mockito.mock(PageManager.class);
+        initMocks(this);
     }
 
     @Test
     public void resolveResource_pathStartsWithSlash() {
-        this.pathMock = "/fake/path/for/testing";
+        this.pathSample = "/fake/path/for/testing";
 
-        when(this.resourceResolverMock.getResource(this.pathMock))
+        when(this.resourceResolverMock.getResource(this.pathSample))
          .thenReturn(this.resourceMock);
 
-        assertEquals(this.resourceMock, Utils.resolveResource(this.resourceResolverMock, this.pathMock));
+        assertEquals(this.resourceMock, Utils.resolveResource(this.resourceResolverMock, this.pathSample));
     }
 
     @Test
     public void resolveResource_pathStartsWithoutSlashResourceNull() {
-        this.pathMock = "fake/path/for/testing";
-        this.searchPathMock = new String[] { "/base/fake/path" };
+        this.pathSample = "fake/path/for/testing";
+        this.searchPathSample = new String[] { "/base/fake/path" };
 
         when(this.resourceResolverMock.getSearchPath())
-         .thenReturn(this.searchPathMock);
-        when(this.resourceResolverMock.getResource(this.searchPathMock[0] + this.pathMock))
+         .thenReturn(this.searchPathSample);
+        when(this.resourceResolverMock.getResource(this.searchPathSample[0] + this.pathSample))
          .thenReturn(null);
 
-        assertEquals(null, Utils.resolveResource(this.resourceResolverMock, this.pathMock));
+        assertEquals(null, Utils.resolveResource(this.resourceResolverMock, this.pathSample));
     }
 
     @Test
     public void resolveResource_pathStartsWithoutSlashResourceNotNull() {
-        this.pathMock = "fake/path/for/testing";
-        this.searchPathMock = new String[] { "/base/fake/path" };
+        this.pathSample = "fake/path/for/testing";
+        this.searchPathSample = new String[] { "/base/fake/path" };
 
         when(this.resourceResolverMock.getSearchPath())
-         .thenReturn(this.searchPathMock);
-        when(this.resourceResolverMock.getResource(this.searchPathMock[0] + this.pathMock))
+         .thenReturn(this.searchPathSample);
+        when(this.resourceResolverMock.getResource(this.searchPathSample[0] + this.pathSample))
          .thenReturn(this.resourceMock);
 
-        assertEquals(this.resourceMock, Utils.resolveResource(this.resourceResolverMock, this.pathMock));
+        assertEquals(this.resourceMock, Utils.resolveResource(this.resourceResolverMock, this.pathSample));
     }
 
     @Test
     public void getTemplateResourceTypes_pageNull() {
-        this.resourceTypesMock = new HashSet<String>();
+        this.resourceTypesSample = new HashSet<String>();
 
-        this.resourceTypesMock.add("dummyType");
-        this.resourceTypesMock.add("fakeType");
+        this.resourceTypesSample.add("dummyType");
+        this.resourceTypesSample.add("fakeType");
 
         when(this.pageMock.getTemplate())
          .thenReturn(null);
 
-        assertEquals(this.resourceTypesMock, Utils.getTemplateResourceTypes(this.pageMock, this.resourceTypeRegexMock, this.resourceResolverMock, this.resourceTypesMock));
+        assertEquals(this.resourceTypesSample, Utils.getTemplateResourceTypes(this.pageMock, this.resourceTypeRegexSample, this.resourceResolverMock, this.resourceTypesSample));
     }
 
     @Test
     public void getTemplateResourceTypes_resourceNull() {
-        this.pathMock = "/fake/path/for/testing";
-        this.resourceTypesMock = new HashSet<String>();
+        this.pathSample = "/fake/path/for/testing";
+        this.resourceTypesSample = new HashSet<String>();
 
-        this.resourceTypesMock.add("dummyType");
-        this.resourceTypesMock.add("fakeType");
+        this.resourceTypesSample.add("dummyType");
+        this.resourceTypesSample.add("fakeType");
 
         when(this.pageMock.getTemplate())
          .thenReturn(this.templateMock);
         when(this.templateMock.getPath())
-         .thenReturn(this.pathMock);
-        when(this.resourceResolverMock.getResource(this.pathMock + AllowedComponentList.STRUCTURE_JCR_CONTENT))
+         .thenReturn(this.pathSample);
+        when(this.resourceResolverMock.getResource(this.pathSample + AllowedComponentList.STRUCTURE_JCR_CONTENT))
          .thenReturn(null);
 
-        assertEquals(this.resourceTypesMock, Utils.getTemplateResourceTypes(this.pageMock, this.resourceTypeRegexMock, this.resourceResolverMock, this.resourceTypesMock));
+        assertEquals(this.resourceTypesSample, Utils.getTemplateResourceTypes(this.pageMock, this.resourceTypeRegexSample, this.resourceResolverMock, this.resourceTypesSample));
     }
 
     @Test
     public void getResourceTypes_resourceNull() {
-        assertEquals(null, Utils.getResourceTypes(null, this.resourceTypeRegexMock, this.resourceTypesMock));
+        assertEquals(null, Utils.getResourceTypes(null, this.resourceTypeRegexSample, this.resourceTypesSample));
     }
 
     @Test
-    public void getResourceTypes_resourceNotNull() {
-        this.resourceTypesMock = new HashSet<String>();
+    public void getResourceTypes_resourceCorrect() {
+        this.resourceTypesSample = new HashSet<String>();
 
-        this.resourceTypesMock.add("dummyType");
+        this.resourceTypesSample.add("dummyType");
 
         when(this.resourceMock.getResourceType())
          .thenReturn("fakeType");
@@ -154,17 +148,17 @@ public class UtilsTest {
         resourceTypesResult.add("dummyType");
         resourceTypesResult.add("fakeType");
 
-        assertEquals(resourceTypesResult, Utils.getResourceTypes(this.resourceMock, this.resourceTypeRegexMock, this.resourceTypesMock));
+        assertEquals(resourceTypesResult, Utils.getResourceTypes(this.resourceMock, this.resourceTypeRegexSample, this.resourceTypesSample));
     }
 
     @Test
     public void getURLExtended_pageNull() {
-        this.pathMock = "fake/path/for/testing";
+        this.pathSample = "fake/path/for/testing";
 
-        when(this.pageManagerMock.getPage(this.pathMock))
+        when(this.pageManagerMock.getPage(this.pathSample))
          .thenReturn(null);
 
-        assertEquals(this.pathMock, Utils.getURL(this.slingHttpServletRequestMock, this.pageManagerMock, this.pathMock));
+        assertEquals(this.pathSample, Utils.getURL(this.slingHttpServletRequestMock, this.pageManagerMock, this.pathSample));
     }
 
     @Test
@@ -180,7 +174,7 @@ public class UtilsTest {
     }
 
     @Test
-    public void getURLExtended_vanityUrlNotEmpty() {
+    public void getURLExtended_vanityUrlCorrect() {
         when(this.pageMock.getVanityUrl())
          .thenReturn("testPage.html");
         when(this.slingHttpServletRequestMock.getContextPath())

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/UtilsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/UtilsTest.java
@@ -40,22 +40,22 @@ import java.util.HashSet;
 
 public class UtilsTest {
     @Mock
-    ResourceResolver resourceResolverMock;
+    private ResourceResolver resourceResolverMock;
     @Mock
-    Resource resourceMock;
+    private Resource resourceMock;
     @Mock
-    Page pageMock;
+    private Page pageMock;
     @Mock
-    Template templateMock;
+    private Template templateMock;
     @Mock
-    SlingHttpServletRequest slingHttpServletRequestMock;
+    private SlingHttpServletRequest slingHttpServletRequestMock;
     @Mock
-    PageManager pageManagerMock;
+    private PageManager pageManagerMock;
 
-    String pathSample;
-    String[] searchPathSample;
-    String resourceTypeRegexSample;
-    Set<String> resourceTypesSample;
+    private String pathSample;
+    private String[] searchPathSample;
+    private String resourceTypeRegexSample;
+    private Set<String> resourceTypesSample;
 
     @BeforeEach
     void setUp() {

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/UtilsTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/UtilsTest.java
@@ -1,0 +1,213 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal;
+
+import org.mockito.Mockito;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+
+import com.adobe.cq.wcm.core.components.internal.Utils;
+import com.day.cq.wcm.foundation.AllowedComponentList;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.Resource;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.Template;
+import java.util.Set;
+import java.util.HashSet;
+
+public class UtilsTest {
+    // resolveResource method
+    ResourceResolver resourceResolverMock;
+    Resource resourceMock;
+    String pathMock;
+    String[] searchPathMock;
+
+    // getTemplateResourceTypes method
+    Page pageMock;
+    Template templateMock;
+    String resourceTypeRegexMock;
+    Set<String> resourceTypesMock;
+
+    // getURL method
+    SlingHttpServletRequest slingHttpServletRequestMock;
+    PageManager pageManagerMock;
+
+    @BeforeEach
+    void setUp() {
+        // resolveResource method
+        this.resourceResolverMock = Mockito.mock(ResourceResolver.class);
+        this.resourceMock = Mockito.mock(Resource.class);
+
+        // getTemplateResourceTypes method
+        this.pageMock = Mockito.mock(Page.class);
+        this.templateMock = Mockito.mock(Template.class);
+
+        // getURL method
+        this.slingHttpServletRequestMock = Mockito.mock(SlingHttpServletRequest.class);
+        this.pageManagerMock = Mockito.mock(PageManager.class);
+    }
+
+    @Test
+    public void resolveResource_pathStartsWithSlash() {
+        this.pathMock = "/fake/path/for/testing";
+
+        Mockito
+         .when(this.resourceResolverMock.getResource(this.pathMock))
+         .thenReturn(this.resourceMock);
+
+        assertEquals(this.resourceMock, Utils.resolveResource(this.resourceResolverMock, this.pathMock));
+    }
+
+    @Test
+    public void resolveResource_pathStartsWithoutSlashResourceNull() {
+        this.pathMock = "fake/path/for/testing";
+        this.searchPathMock = new String[] { "/base/fake/path" };
+
+        Mockito
+         .when(this.resourceResolverMock.getSearchPath())
+         .thenReturn(this.searchPathMock);
+
+        Mockito
+         .when(this.resourceResolverMock.getResource(this.searchPathMock[0] + this.pathMock))
+         .thenReturn(null);
+
+        assertEquals(null, Utils.resolveResource(this.resourceResolverMock, this.pathMock));
+    }
+
+    @Test
+    public void resolveResource_pathStartsWithoutSlashResourceNotNull() {
+        this.pathMock = "fake/path/for/testing";
+        this.searchPathMock = new String[] { "/base/fake/path" };
+
+        Mockito
+         .when(this.resourceResolverMock.getSearchPath())
+         .thenReturn(this.searchPathMock);
+
+        Mockito
+         .when(this.resourceResolverMock.getResource(this.searchPathMock[0] + this.pathMock))
+         .thenReturn(this.resourceMock);
+
+        assertEquals(this.resourceMock, Utils.resolveResource(this.resourceResolverMock, this.pathMock));
+    }
+
+    @Test
+    public void getTemplateResourceTypes_pageNull() {
+        this.resourceTypesMock = new HashSet<String>();
+
+        this.resourceTypesMock.add("dummyType");
+        this.resourceTypesMock.add("fakeType");
+
+        Mockito
+         .when(this.pageMock.getTemplate())
+         .thenReturn(null);
+
+        assertEquals(this.resourceTypesMock, Utils.getTemplateResourceTypes(this.pageMock, this.resourceTypeRegexMock, this.resourceResolverMock, this.resourceTypesMock));
+    }
+
+    @Test
+    public void getTemplateResourceTypes_resourceNull() {
+        this.pathMock = "/fake/path/for/testing";
+        this.resourceTypesMock = new HashSet<String>();
+
+        this.resourceTypesMock.add("dummyType");
+        this.resourceTypesMock.add("fakeType");
+
+        Mockito
+         .when(this.pageMock.getTemplate())
+         .thenReturn(this.templateMock);
+
+        Mockito
+         .when(this.templateMock.getPath())
+         .thenReturn(this.pathMock);
+
+        Mockito
+         .when(this.resourceResolverMock.getResource(this.pathMock + AllowedComponentList.STRUCTURE_JCR_CONTENT))
+         .thenReturn(null);
+
+        assertEquals(this.resourceTypesMock, Utils.getTemplateResourceTypes(this.pageMock, this.resourceTypeRegexMock, this.resourceResolverMock, this.resourceTypesMock));
+    }
+
+    @Test
+    public void getResourceTypes_resourceNull() {
+        assertEquals(null, Utils.getResourceTypes(null, this.resourceTypeRegexMock, this.resourceTypesMock));
+    }
+
+    @Test
+    public void getResourceTypes_resourceNotNull() {
+        this.resourceTypesMock = new HashSet<String>();
+
+        this.resourceTypesMock.add("dummyType");
+
+        Mockito
+         .when(this.resourceMock.getResourceType())
+         .thenReturn("fakeType");
+
+        Set<String> resourceTypesResult = new HashSet<String>();
+
+        resourceTypesResult.add("dummyType");
+        resourceTypesResult.add("fakeType");
+
+        assertEquals(resourceTypesResult, Utils.getResourceTypes(this.resourceMock, this.resourceTypeRegexMock, this.resourceTypesMock));
+    }
+
+    @Test
+    public void getURLExtended_pageNull() {
+        this.pathMock = "fake/path/for/testing";
+
+        Mockito
+         .when(this.pageManagerMock.getPage(this.pathMock))
+         .thenReturn(null);
+
+        assertEquals(this.pathMock, Utils.getURL(this.slingHttpServletRequestMock, this.pageManagerMock, this.pathMock));
+    }
+
+    @Test
+    public void getURLExtended_vanityUrlEmpty() {
+        Mockito
+         .when(this.pageMock.getVanityUrl())
+         .thenReturn("");
+
+        Mockito
+         .when(this.pageMock.getPath())
+         .thenReturn("testPage");
+
+        Mockito
+         .when(this.slingHttpServletRequestMock.getContextPath())
+         .thenReturn("/fake/path/for/testing/");
+
+        assertEquals("/fake/path/for/testing/testPage.html", Utils.getURL(this.slingHttpServletRequestMock, this.pageMock));
+    }
+
+    @Test
+    public void getURLExtended_vanityUrlNotEmpty() {
+        Mockito
+         .when(this.pageMock.getVanityUrl())
+         .thenReturn("testPage.html");
+
+        Mockito
+         .when(this.slingHttpServletRequestMock.getContextPath())
+         .thenReturn("/fake/path/for/testing/");
+
+        assertEquals("/fake/path/for/testing/testPage.html", Utils.getURL(this.slingHttpServletRequestMock, this.pageMock));
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibraryImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ClientLibraryImplTest.java
@@ -1,0 +1,108 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1;
+
+import org.mockito.Mockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
+import static uk.org.lidalia.slf4jtest.LoggingEvent.error;
+
+import com.adobe.cq.wcm.core.components.internal.Utils;
+import com.adobe.cq.wcm.core.components.services.ClientLibraryAggregatorService;
+import com.day.cq.wcm.api.Page;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.Resource;
+import java.util.Set;
+import java.util.HashSet;
+import org.apache.sling.api.resource.LoginException;
+
+public class ClientLibraryImplTest {
+    private TestLogger testLogger;
+
+    @Mock
+    private ClientLibraryAggregatorService clientLibraryAggregatorServiceMock;
+    @Mock
+    private Page pageMock;
+    @Mock
+    private ResourceResolver resourceResolverMock;
+    @Mock
+    private Resource resourceMock;
+    @InjectMocks
+    private ClientLibraryImpl cl;
+
+    private String categories = "category";
+    private String type = "js";
+    private String primaryPath = "/primary/path";
+    private String fallbackPath = "/fallback/path";
+
+    String resourceTypeRegexSample;
+
+    @BeforeEach
+    void setUp() {
+        this.testLogger = TestLoggerFactory.getTestLogger(ClientLibraryImpl.class);
+
+        initMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TestLoggerFactory.clear();
+    }
+
+    @Test
+    public void getInline() {
+        this.cl.categories = this.categories;
+        this.cl.type = this.type;
+
+        when(this.clientLibraryAggregatorServiceMock.getClientLibOutput(this.categories, this.type))
+          .thenReturn("output inline");
+
+        assertEquals("output inline", this.cl.getInline());
+    }
+
+    @Test
+    public void getInlineLimited_correct() throws LoginException {
+        this.cl.categories = this.categories;
+        this.cl.type = this.type;
+        this.cl.primaryPath = this.primaryPath;
+        this.cl.fallbackPath = this.fallbackPath;
+
+        Set<String> resourceTypes = Utils.getResourceTypes(this.resourceMock, this.resourceTypeRegexSample, new HashSet<>());
+
+        when(this.pageMock.getContentResource())
+          .thenReturn(this.resourceMock);
+        when(this.clientLibraryAggregatorServiceMock.getResourceTypeRegex())
+          .thenReturn(this.resourceTypeRegexSample);
+        when(this.clientLibraryAggregatorServiceMock.getClientlibResourceResolver())
+        .thenReturn(this.resourceResolverMock);
+        when(this.clientLibraryAggregatorServiceMock.getClientLibOutput(this.categories, this.type, resourceTypes, this.primaryPath, this.fallbackPath))
+          .thenReturn("output inline");
+
+        assertEquals("output inline", this.cl.getInlineLimited());
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImplTest.java
@@ -38,7 +38,6 @@ import org.apache.sling.api.resource.LoginException;
 import org.apache.commons.io.IOUtils;
 import java.nio.charset.StandardCharsets;
 import com.adobe.cq.wcm.core.components.internal.Utils;
-
 import static java.util.Arrays.asList;
 import java.util.Collections;
 import java.util.Collection;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImplTest.java
@@ -1,0 +1,239 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services;
+
+import org.mockito.Mockito;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+
+import java.io.InputStream;
+import java.io.IOException;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.commons.io.IOUtils;
+import java.nio.charset.StandardCharsets;
+import com.adobe.cq.wcm.core.components.internal.Utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
+import static uk.org.lidalia.slf4jtest.LoggingEvent.debug;
+import static uk.org.lidalia.slf4jtest.LoggingEvent.error;
+
+import static java.util.Arrays.asList;
+import java.util.Collections;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ArrayList;
+import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
+import com.adobe.granite.ui.clientlibs.HtmlLibrary;
+import com.adobe.granite.ui.clientlibs.ClientLibrary;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+
+public class ClientLibraryAggregatorServiceImplTest {
+    private TestLogger testLogger;
+
+    private ClientLibraryAggregatorServiceImpl cl;
+    private String categoryCsv;
+    private String type;
+    private Set<String> resourceTypes;
+    private String primaryPath;
+    private String fallbackPath;
+
+    private InputStream inputStreamSample;
+
+    private ClientLibrary clientLibraryMock;
+    private Collection<ClientLibrary> clientLibraryCollection;
+    private HtmlLibrary htmlLibraryMock;
+    private HtmlLibraryManager htmlLibraryManagerMock;
+
+    private ResourceResolverFactory resourceResolverFactoryMock;
+    private ResourceResolver resourceResolverMock;
+
+    @BeforeEach
+    void setUp() {
+        this.cl = new ClientLibraryAggregatorServiceImpl();
+
+        this.testLogger = TestLoggerFactory.getTestLogger(ClientLibraryAggregatorServiceImpl.class);
+
+        this.htmlLibraryManagerMock = Mockito.mock(HtmlLibraryManager.class);
+        this.clientLibraryMock = Mockito.mock(ClientLibrary.class);
+        this.htmlLibraryMock = Mockito.mock(HtmlLibrary.class);
+
+        this.clientLibraryCollection = new LinkedList<ClientLibrary>();
+        clientLibraryCollection.add(clientLibraryMock);
+
+        this.resourceResolverFactoryMock = Mockito.mock(ResourceResolverFactory.class);
+        this.resourceResolverMock = Mockito.mock(ResourceResolver.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TestLoggerFactory.clear();
+    }
+
+    @Test
+    public void getClientLibOutput_categoryCsvEmpty() {
+        this.categoryCsv = "";
+        this.type = "js";
+
+        assertEquals("", this.cl.getClientLibOutput(this.categoryCsv, this.type));
+    }
+
+    @Test
+    public void getClientLibOutput_typeEmpty() {
+        this.categoryCsv = "cmp-examples.base,cmp-examples.site";
+        this.type = "";
+
+        assertEquals("", this.cl.getClientLibOutput(this.categoryCsv, this.type));
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(error("No client libraries of type '{}'.", this.type)));
+    }
+
+    @Test
+    public void getClientLibOutput_typeWrong() {
+        this.categoryCsv = "cmp-examples.base,cmp-examples.site";
+        this.type = "txt";
+
+        assertEquals("", this.cl.getClientLibOutput(this.categoryCsv, this.type));
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(error("No client libraries of type '{}'.", this.type)));
+    }
+
+    @Test
+    public void getClientLibOutput_libraryIsNull() {
+        this.categoryCsv = "cmp-examples.base,cmp-examples.site";
+        this.type = "js";
+
+        Mockito
+          .when(this.htmlLibraryManagerMock.getLibraries(this.cl.getClientLibArrayCategories(this.categoryCsv), this.cl.getClientLibType(this.type), false, true))
+          .thenReturn(this.clientLibraryCollection);
+        Mockito
+          .when(this.htmlLibraryManagerMock.getLibrary(this.cl.getClientLibType(this.type), this.clientLibraryMock.getPath()))
+          .thenReturn(null);
+
+        this.cl.htmlLibraryManager = this.htmlLibraryManagerMock;
+
+        assertEquals("", this.cl.getClientLibOutput(this.categoryCsv, this.type));
+    }
+
+    @Test
+    public void getClientLibOutput_libraryIncorrect() throws IOException {
+        this.categoryCsv = "cmp-examples.base,cmp-examples.site";
+        this.type = "js";
+
+        this.inputStreamSample = Mockito.mock(InputStream.class);
+
+        Mockito
+          .when(this.htmlLibraryManagerMock.getLibraries(this.cl.getClientLibArrayCategories(this.categoryCsv), this.cl.getClientLibType(this.type), false, true))
+          .thenReturn(this.clientLibraryCollection);
+        Mockito
+          .when(this.htmlLibraryManagerMock.getLibrary(this.cl.getClientLibType(this.type), this.clientLibraryMock.getPath()))
+          .thenReturn(this.htmlLibraryMock);
+        Mockito
+          .when(this.htmlLibraryMock.getInputStream(false))
+          .thenReturn(this.inputStreamSample);
+
+        this.cl.htmlLibraryManager = this.htmlLibraryManagerMock;
+
+        assertEquals("", this.cl.getClientLibOutput(this.categoryCsv, this.type));
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(error("Error getting input stream from clientlib with path '{}'.", clientLibraryMock.getPath())));
+    }
+
+    @Test
+    public void getClientLibOutput_libraryCorrect() throws IOException {
+        this.categoryCsv = "cmp-examples.base,cmp-examples.site";
+        this.type = "js";
+
+        String inputSample = "Some test data for my input stream";
+        this.inputStreamSample = IOUtils.toInputStream(inputSample, StandardCharsets.UTF_8);
+
+        Mockito
+          .when(this.htmlLibraryManagerMock.getLibraries(this.cl.getClientLibArrayCategories(this.categoryCsv), this.cl.getClientLibType(this.type), false, true))
+          .thenReturn(this.clientLibraryCollection);
+        Mockito
+          .when(this.htmlLibraryManagerMock.getLibrary(this.cl.getClientLibType(this.type), this.clientLibraryMock.getPath()))
+          .thenReturn(this.htmlLibraryMock);
+        Mockito
+          .when(this.htmlLibraryMock.getInputStream(false))
+          .thenReturn(this.inputStreamSample);
+
+        this.cl.htmlLibraryManager = this.htmlLibraryManagerMock;
+
+        assertEquals(inputSample, this.cl.getClientLibOutput(this.categoryCsv, this.type));
+    }
+
+    @Test
+    public void getClientLibOutputExtended_primaryAndFallbackPathsIncorrect() throws IOException {
+        this.categoryCsv = "cmp-examples.base,cmp-examples.site";
+        this.type = "";
+        this.resourceTypes = new HashSet<String>();
+        this.primaryPath = "";
+        this.fallbackPath = "";
+
+        assertEquals("", this.cl.getClientLibOutput(this.categoryCsv, this.type, this.resourceTypes, this.primaryPath, this.fallbackPath));
+        assertThat(this.testLogger.getLoggingEvents(), is(asList(debug("Resource type clientlib aggregator must have a path value."))));
+    }
+
+    @Test
+    public void getClientLibOutputExtended_primaryPathCorrectTypeEmpty() throws LoginException {
+        this.categoryCsv = "cmp-examples.base,cmp-examples.site";
+        this.type = "";
+        this.resourceTypes = new HashSet<String>();
+        this.primaryPath = "path/to/resources";
+        this.fallbackPath = "";
+
+        this.resourceTypes.add("/dummyType");
+
+        Mockito
+          .when(this.resourceResolverFactoryMock.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, Utils.CLIENTLIB_SUBSERVICE)))
+          .thenReturn(this.resourceResolverMock);
+
+        this.cl.resolverFactory = this.resourceResolverFactoryMock;
+
+        assertEquals("", this.cl.getClientLibOutput(this.categoryCsv, this.type, this.resourceTypes, this.primaryPath, this.fallbackPath));
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(error("No client libraries of type '{}'.", this.type)));
+    }
+
+    @Test
+    public void getClientLibOutputExtended_fallbackPathCorrectTypeEmpty() throws LoginException {
+        this.categoryCsv = "cmp-examples.base,cmp-examples.site";
+        this.type = "";
+        this.resourceTypes = new HashSet<String>();
+        this.primaryPath = "";
+        this.fallbackPath = "path/to/resources";
+
+        this.resourceTypes.add("/dummyType");
+
+        Mockito
+          .when(this.resourceResolverFactoryMock.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, Utils.CLIENTLIB_SUBSERVICE)))
+          .thenReturn(this.resourceResolverMock);
+
+        this.cl.resolverFactory = this.resourceResolverFactoryMock;
+
+        assertEquals("", this.cl.getClientLibOutput(this.categoryCsv, this.type, this.resourceTypes, this.primaryPath, this.fallbackPath));
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(error("No client libraries of type '{}'.", this.type)));
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImplTest.java
@@ -15,7 +15,9 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.services;
 
-import org.mockito.Mockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.MockitoAnnotations.initMocks;
 import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
@@ -25,20 +27,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
+import static uk.org.lidalia.slf4jtest.LoggingEvent.debug;
+import static uk.org.lidalia.slf4jtest.LoggingEvent.error;
+
 import java.io.InputStream;
 import java.io.IOException;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.commons.io.IOUtils;
 import java.nio.charset.StandardCharsets;
 import com.adobe.cq.wcm.core.components.internal.Utils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
-import static uk.org.lidalia.slf4jtest.LoggingEvent.debug;
-import static uk.org.lidalia.slf4jtest.LoggingEvent.error;
 
 import static java.util.Arrays.asList;
 import java.util.Collections;
@@ -58,38 +57,37 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 public class ClientLibraryAggregatorServiceImplTest {
     private TestLogger testLogger;
 
+    @Mock
+    private ClientLibrary clientLibraryMock;
+    @Mock
+    private HtmlLibrary htmlLibraryMock;
+    @Mock
+    private HtmlLibraryManager htmlLibraryManagerMock;
+    @Mock
+    private ResourceResolverFactory resourceResolverFactoryMock;
+    @Mock
+    private ResourceResolver resourceResolverMock;
+    @Mock
+    private InputStream inputStreamSample;
+    @InjectMocks
     private ClientLibraryAggregatorServiceImpl cl;
+
     private String categoryCsv;
     private String type;
     private Set<String> resourceTypes;
     private String primaryPath;
     private String fallbackPath;
 
-    private InputStream inputStreamSample;
-
-    private ClientLibrary clientLibraryMock;
     private Collection<ClientLibrary> clientLibraryCollection;
-    private HtmlLibrary htmlLibraryMock;
-    private HtmlLibraryManager htmlLibraryManagerMock;
-
-    private ResourceResolverFactory resourceResolverFactoryMock;
-    private ResourceResolver resourceResolverMock;
 
     @BeforeEach
     void setUp() {
-        this.cl = new ClientLibraryAggregatorServiceImpl();
-
         this.testLogger = TestLoggerFactory.getTestLogger(ClientLibraryAggregatorServiceImpl.class);
 
-        this.htmlLibraryManagerMock = Mockito.mock(HtmlLibraryManager.class);
-        this.clientLibraryMock = Mockito.mock(ClientLibrary.class);
-        this.htmlLibraryMock = Mockito.mock(HtmlLibrary.class);
+        initMocks(this);
 
         this.clientLibraryCollection = new LinkedList<ClientLibrary>();
         clientLibraryCollection.add(clientLibraryMock);
-
-        this.resourceResolverFactoryMock = Mockito.mock(ResourceResolverFactory.class);
-        this.resourceResolverMock = Mockito.mock(ResourceResolver.class);
     }
 
     @AfterEach
@@ -133,8 +131,6 @@ public class ClientLibraryAggregatorServiceImplTest {
         when(this.htmlLibraryManagerMock.getLibrary(this.cl.getClientLibType(this.type), this.clientLibraryMock.getPath()))
           .thenReturn(null);
 
-        this.cl.htmlLibraryManager = this.htmlLibraryManagerMock;
-
         assertEquals("", this.cl.getClientLibOutput(this.categoryCsv, this.type));
     }
 
@@ -143,16 +139,12 @@ public class ClientLibraryAggregatorServiceImplTest {
         this.categoryCsv = "cmp-examples.base,cmp-examples.site";
         this.type = "js";
 
-        this.inputStreamSample = Mockito.mock(InputStream.class);
-
         when(this.htmlLibraryManagerMock.getLibraries(this.cl.getClientLibArrayCategories(this.categoryCsv), this.cl.getClientLibType(this.type), false, true))
           .thenReturn(this.clientLibraryCollection);
         when(this.htmlLibraryManagerMock.getLibrary(this.cl.getClientLibType(this.type), this.clientLibraryMock.getPath()))
           .thenReturn(this.htmlLibraryMock);
         when(this.htmlLibraryMock.getInputStream(false))
           .thenReturn(this.inputStreamSample);
-
-        this.cl.htmlLibraryManager = this.htmlLibraryManagerMock;
 
         assertEquals("", this.cl.getClientLibOutput(this.categoryCsv, this.type));
         assertThat(this.testLogger.getLoggingEvents(), hasItem(error("Error getting input stream from clientlib with path '{}'.", clientLibraryMock.getPath())));
@@ -172,8 +164,6 @@ public class ClientLibraryAggregatorServiceImplTest {
           .thenReturn(this.htmlLibraryMock);
         when(this.htmlLibraryMock.getInputStream(false))
           .thenReturn(this.inputStreamSample);
-
-        this.cl.htmlLibraryManager = this.htmlLibraryManagerMock;
 
         assertEquals(inputSample, this.cl.getClientLibOutput(this.categoryCsv, this.type));
     }
@@ -203,8 +193,6 @@ public class ClientLibraryAggregatorServiceImplTest {
         when(this.resourceResolverFactoryMock.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, Utils.CLIENTLIB_SUBSERVICE)))
           .thenReturn(this.resourceResolverMock);
 
-        this.cl.resolverFactory = this.resourceResolverFactoryMock;
-
         assertEquals("", this.cl.getClientLibOutput(this.categoryCsv, this.type, this.resourceTypes, this.primaryPath, this.fallbackPath));
         assertThat(this.testLogger.getLoggingEvents(), hasItem(error("No client libraries of type '{}'.", this.type)));
     }
@@ -221,8 +209,6 @@ public class ClientLibraryAggregatorServiceImplTest {
 
         when(this.resourceResolverFactoryMock.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, Utils.CLIENTLIB_SUBSERVICE)))
           .thenReturn(this.resourceResolverMock);
-
-        this.cl.resolverFactory = this.resourceResolverFactoryMock;
 
         assertEquals("", this.cl.getClientLibOutput(this.categoryCsv, this.type, this.resourceTypes, this.primaryPath, this.fallbackPath));
         assertThat(this.testLogger.getLoggingEvents(), hasItem(error("No client libraries of type '{}'.", this.type)));

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/ClientLibraryAggregatorServiceImplTest.java
@@ -16,6 +16,7 @@
 package com.adobe.cq.wcm.core.components.internal.services;
 
 import org.mockito.Mockito;
+import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -127,11 +128,9 @@ public class ClientLibraryAggregatorServiceImplTest {
         this.categoryCsv = "cmp-examples.base,cmp-examples.site";
         this.type = "js";
 
-        Mockito
-          .when(this.htmlLibraryManagerMock.getLibraries(this.cl.getClientLibArrayCategories(this.categoryCsv), this.cl.getClientLibType(this.type), false, true))
+        when(this.htmlLibraryManagerMock.getLibraries(this.cl.getClientLibArrayCategories(this.categoryCsv), this.cl.getClientLibType(this.type), false, true))
           .thenReturn(this.clientLibraryCollection);
-        Mockito
-          .when(this.htmlLibraryManagerMock.getLibrary(this.cl.getClientLibType(this.type), this.clientLibraryMock.getPath()))
+        when(this.htmlLibraryManagerMock.getLibrary(this.cl.getClientLibType(this.type), this.clientLibraryMock.getPath()))
           .thenReturn(null);
 
         this.cl.htmlLibraryManager = this.htmlLibraryManagerMock;
@@ -146,14 +145,11 @@ public class ClientLibraryAggregatorServiceImplTest {
 
         this.inputStreamSample = Mockito.mock(InputStream.class);
 
-        Mockito
-          .when(this.htmlLibraryManagerMock.getLibraries(this.cl.getClientLibArrayCategories(this.categoryCsv), this.cl.getClientLibType(this.type), false, true))
+        when(this.htmlLibraryManagerMock.getLibraries(this.cl.getClientLibArrayCategories(this.categoryCsv), this.cl.getClientLibType(this.type), false, true))
           .thenReturn(this.clientLibraryCollection);
-        Mockito
-          .when(this.htmlLibraryManagerMock.getLibrary(this.cl.getClientLibType(this.type), this.clientLibraryMock.getPath()))
+        when(this.htmlLibraryManagerMock.getLibrary(this.cl.getClientLibType(this.type), this.clientLibraryMock.getPath()))
           .thenReturn(this.htmlLibraryMock);
-        Mockito
-          .when(this.htmlLibraryMock.getInputStream(false))
+        when(this.htmlLibraryMock.getInputStream(false))
           .thenReturn(this.inputStreamSample);
 
         this.cl.htmlLibraryManager = this.htmlLibraryManagerMock;
@@ -170,14 +166,11 @@ public class ClientLibraryAggregatorServiceImplTest {
         String inputSample = "Some test data for my input stream";
         this.inputStreamSample = IOUtils.toInputStream(inputSample, StandardCharsets.UTF_8);
 
-        Mockito
-          .when(this.htmlLibraryManagerMock.getLibraries(this.cl.getClientLibArrayCategories(this.categoryCsv), this.cl.getClientLibType(this.type), false, true))
+        when(this.htmlLibraryManagerMock.getLibraries(this.cl.getClientLibArrayCategories(this.categoryCsv), this.cl.getClientLibType(this.type), false, true))
           .thenReturn(this.clientLibraryCollection);
-        Mockito
-          .when(this.htmlLibraryManagerMock.getLibrary(this.cl.getClientLibType(this.type), this.clientLibraryMock.getPath()))
+        when(this.htmlLibraryManagerMock.getLibrary(this.cl.getClientLibType(this.type), this.clientLibraryMock.getPath()))
           .thenReturn(this.htmlLibraryMock);
-        Mockito
-          .when(this.htmlLibraryMock.getInputStream(false))
+        when(this.htmlLibraryMock.getInputStream(false))
           .thenReturn(this.inputStreamSample);
 
         this.cl.htmlLibraryManager = this.htmlLibraryManagerMock;
@@ -207,8 +200,7 @@ public class ClientLibraryAggregatorServiceImplTest {
 
         this.resourceTypes.add("/dummyType");
 
-        Mockito
-          .when(this.resourceResolverFactoryMock.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, Utils.CLIENTLIB_SUBSERVICE)))
+        when(this.resourceResolverFactoryMock.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, Utils.CLIENTLIB_SUBSERVICE)))
           .thenReturn(this.resourceResolverMock);
 
         this.cl.resolverFactory = this.resourceResolverFactoryMock;
@@ -227,8 +219,7 @@ public class ClientLibraryAggregatorServiceImplTest {
 
         this.resourceTypes.add("/dummyType");
 
-        Mockito
-          .when(this.resourceResolverFactoryMock.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, Utils.CLIENTLIB_SUBSERVICE)))
+        when(this.resourceResolverFactoryMock.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, Utils.CLIENTLIB_SUBSERVICE)))
           .thenReturn(this.resourceResolverMock);
 
         this.cl.resolverFactory = this.resourceResolverFactoryMock;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpModeForwardFilterTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpModeForwardFilterTest.java
@@ -1,0 +1,195 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.amp;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.any;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
+import static uk.org.lidalia.slf4jtest.LoggingEvent.debug;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.request.RequestPathInfo;
+import org.apache.sling.api.request.RequestDispatcherOptions;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import java.util.HashMap;
+import java.util.Map;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.Page;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import com.adobe.cq.commerce.common.ValueMapDecorator;
+
+public class AmpModeForwardFilterTest {
+    private static final String AMP_MODE_PROP = "ampMode";
+
+    private TestLogger testLogger;
+
+    private SlingHttpServletRequest slingHttpServletRequestMock;
+    @Mock
+    private FilterChain filterChainMock;
+    @Mock(extraInterfaces = SlingHttpServletRequest.class)
+    private ServletRequest servletRequestMock;
+    @Mock
+    private ServletResponse servletResponseMock;
+    @Mock
+    private RequestPathInfo requestPathInfoMock;
+    @Mock
+    private RequestDispatcher requestDispatcherMock;
+    @Mock
+    private PageManager pageManagerMock;
+    @Mock
+    private Page pageMock;
+    @Mock
+    private ResourceResolver resourceResolverMock;
+    @Mock
+    private Resource resourceMock;
+    @InjectMocks
+    private AmpModeForwardFilter amff;
+
+    private ValueMap mapSample;
+
+    @BeforeEach
+    void setUp() {
+        this.testLogger = TestLoggerFactory.getTestLogger(AmpModeForwardFilter.class);
+
+        initMocks(this);
+        this.slingHttpServletRequestMock = (SlingHttpServletRequest) this.servletRequestMock;
+    }
+
+    @AfterEach
+    void tearDown() {
+        TestLoggerFactory.clear();
+    }
+
+    @Test
+    public void doFilter_noAmpForwardFalse() throws IOException, ServletException {
+        Map<String, Object> map = new HashMap<String, Object>(){{
+            put(AMP_MODE_PROP, "noAmp");
+        }};
+        this.mapSample = new ValueMapDecorator(map);
+
+        when(this.slingHttpServletRequestMock.getRequestPathInfo())
+          .thenReturn(this.requestPathInfoMock);
+        when(this.requestPathInfoMock.getSelectorString())
+          .thenReturn("amp");
+
+        when(this.slingHttpServletRequestMock.getResourceResolver())
+          .thenReturn(this.resourceResolverMock);
+        when(this.slingHttpServletRequestMock.getResource())
+          .thenReturn(this.resourceMock);
+        when(this.resourceResolverMock.adaptTo(PageManager.class))
+          .thenReturn(this.pageManagerMock);
+        when(this.pageManagerMock.getContainingPage(this.resourceMock))
+          .thenReturn(this.pageMock);
+        when(this.pageMock.getProperties())
+          .thenReturn(this.mapSample);
+
+
+        when(this.slingHttpServletRequestMock.getRequestDispatcher(any(Resource.class), any(RequestDispatcherOptions.class)))
+          .thenReturn(null);
+
+        this.amff.doFilter(this.servletRequestMock, this.servletResponseMock, this.filterChainMock);
+
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(debug("Request dispatcher is null. AMP mode forwarding aborted.")));
+        verify(this.filterChainMock, times(1)).doFilter(this.servletRequestMock, this.servletResponseMock);
+    }
+
+    @Test
+    public void doFilter_ampOnlyForwardFalse() throws IOException, ServletException {
+        Map<String, Object> map = new HashMap<String, Object>(){{
+            put(AMP_MODE_PROP, "ampOnly");
+        }};
+        this.mapSample = new ValueMapDecorator(map);
+
+        when(this.slingHttpServletRequestMock.getRequestPathInfo())
+          .thenReturn(this.requestPathInfoMock);
+        when(this.requestPathInfoMock.getSelectorString())
+          .thenReturn("");
+
+        when(this.slingHttpServletRequestMock.getResourceResolver())
+          .thenReturn(this.resourceResolverMock);
+        when(this.slingHttpServletRequestMock.getResource())
+          .thenReturn(this.resourceMock);
+        when(this.resourceResolverMock.adaptTo(PageManager.class))
+          .thenReturn(this.pageManagerMock);
+        when(this.pageManagerMock.getContainingPage(this.resourceMock))
+          .thenReturn(this.pageMock);
+        when(this.pageMock.getProperties())
+          .thenReturn(this.mapSample);
+
+
+        when(this.slingHttpServletRequestMock.getRequestDispatcher(any(Resource.class), any(RequestDispatcherOptions.class)))
+          .thenReturn(null);
+
+        this.amff.doFilter(this.servletRequestMock, this.servletResponseMock, this.filterChainMock);
+
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(debug("Request dispatcher is null. AMP mode forwarding aborted.")));
+        verify(this.filterChainMock, times(1)).doFilter(this.servletRequestMock, this.servletResponseMock);
+    }
+
+    @Test
+    public void doFilter_dotPlusAmpForwardFalse() throws IOException, ServletException {
+        Map<String, Object> map = new HashMap<String, Object>(){{
+            put(AMP_MODE_PROP, "ampOnly");
+        }};
+        this.mapSample = new ValueMapDecorator(map);
+
+        when(this.slingHttpServletRequestMock.getRequestPathInfo())
+          .thenReturn(this.requestPathInfoMock);
+        when(this.requestPathInfoMock.getSelectorString())
+          .thenReturn(".amp");
+
+        when(this.slingHttpServletRequestMock.getResourceResolver())
+          .thenReturn(this.resourceResolverMock);
+        when(this.slingHttpServletRequestMock.getResource())
+          .thenReturn(this.resourceMock);
+        when(this.resourceResolverMock.adaptTo(PageManager.class))
+          .thenReturn(this.pageManagerMock);
+        when(this.pageManagerMock.getContainingPage(this.resourceMock))
+          .thenReturn(this.pageMock);
+        when(this.pageMock.getProperties())
+          .thenReturn(this.mapSample);
+
+
+        when(this.slingHttpServletRequestMock.getRequestDispatcher(any(Resource.class), any(RequestDispatcherOptions.class)))
+          .thenReturn(this.requestDispatcherMock);
+
+        this.amff.doFilter(this.servletRequestMock, this.servletResponseMock, this.filterChainMock);
+
+        verify(this.requestDispatcherMock, times(1)).forward(this.slingHttpServletRequestMock, this.servletResponseMock);
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpTransformerFactoryTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpTransformerFactoryTest.java
@@ -1,0 +1,67 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.amp;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import com.adobe.cq.wcm.core.components.internal.services.amp.AmpTransformerFactory;
+import com.adobe.cq.wcm.core.components.internal.services.amp.AmpTransformer;
+
+public class AmpTransformerFactoryTest {
+
+    @Mock
+    private ResourceResolverFactory resourceResolverFactoryMock;
+    @Mock
+    private ResourceResolverFactory resourceResolverFactoryMock2;
+    @Mock
+    private AmpTransformerFactory.Cfg cfgMock;
+    @Mock
+    private AmpTransformerFactory.Cfg cfgMock2;
+    @InjectMocks
+    private AmpTransformerFactory atf;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void testFactory() {
+        assertEquals(AmpTransformer.class, this.atf.createTransformer().getClass());
+
+        this.atf.activate(this.cfgMock);
+        assertEquals(this.cfgMock, this.atf.getCfg());
+        this.atf.activate(this.cfgMock2);
+        assertEquals(this.cfgMock2, this.atf.getCfg());
+
+        this.atf.setResolverFactory(this.resourceResolverFactoryMock);
+        assertEquals(this.resourceResolverFactoryMock, this.atf.getResolverFactory());
+        this.atf.setResolverFactory(this.resourceResolverFactoryMock2);
+        assertEquals(this.resourceResolverFactoryMock2, this.atf.getResolverFactory());
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpTransformerTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpTransformerTest.java
@@ -1,0 +1,449 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.amp;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
+import static uk.org.lidalia.slf4jtest.LoggingEvent.trace;
+import static uk.org.lidalia.slf4jtest.LoggingEvent.debug;
+import static uk.org.lidalia.slf4jtest.LoggingEvent.error;
+
+import com.day.crx.JcrConstants;
+import com.adobe.cq.wcm.core.components.internal.Utils;
+import com.adobe.cq.wcm.core.components.internal.services.amp.AmpTransformerFactory;
+import org.apache.sling.rewriter.ProcessingComponentConfiguration;
+import org.apache.sling.rewriter.ProcessingContext;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.request.RequestPathInfo;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.resource.LoginException;
+import com.day.cq.wcm.api.policies.ContentPolicyManager;
+import com.day.cq.wcm.api.policies.ContentPolicy;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.Page;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.Locator;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Collections;
+import java.io.InputStream;
+import com.adobe.cq.commerce.common.ValueMapDecorator;
+
+public class AmpTransformerTest {
+    private static final String AMP_MODE_PROP = "ampMode";
+
+    private TestLogger testLogger;
+
+    @Mock
+    private AmpTransformerFactory.Cfg cfgMock;
+    @Mock
+    private ProcessingContext processingContextMock;
+    @Mock
+    private ProcessingComponentConfiguration processingComponentConfigurationMock;
+    @Mock
+    private SlingHttpServletRequest slingHttpServletRequestMock;
+    @Mock
+    private RequestPathInfo requestPathInfoMock;
+    @Mock
+    private ResourceResolverFactory resourceResolverFactoryMock;
+    @Mock
+    private ResourceResolver resourceResolverMock;
+    @Mock
+    private Resource resourceMock;
+    @Mock
+    private Resource coreResourceMock;
+    @Mock
+    private Resource supertypeResourceMock;
+    @Mock
+    private ContentPolicyManager contentPolicyManagerMock;
+    @Mock
+    private ContentPolicy contentPolicyMock;
+    @Mock
+    private PageManager pageManagerMock;
+    @Mock
+    private Page pageMock;
+    @Mock
+    private ContentHandler contentHandlerMock;
+    @Mock
+    private Locator locatorMock;
+    @Mock
+    private Attributes attributesMock;
+    @InjectMocks
+    private AmpTransformer at;
+
+    private ValueMap mapSample;
+    private String resourceTypeRegexSample;
+
+    @BeforeEach
+    void setUp() {
+        this.testLogger = TestLoggerFactory.getTestLogger(AmpTransformer.class);
+
+        initMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TestLoggerFactory.clear();
+    }
+
+    @Test
+    public void init_pageManagerNull() {
+        String[] selectors = new String[] {"amp"};
+
+        when(this.processingContextMock.getRequest())
+          .thenReturn(this.slingHttpServletRequestMock);
+        when(this.slingHttpServletRequestMock.getResourceResolver())
+          .thenReturn(this.resourceResolverMock);
+        when(this.resourceResolverMock.adaptTo(PageManager.class))
+          .thenReturn(null);
+        when(this.resourceResolverMock.adaptTo(ContentPolicyManager.class))
+          .thenReturn(null);
+        when(this.slingHttpServletRequestMock.getRequestPathInfo())
+          .thenReturn(this.requestPathInfoMock);
+        when(this.requestPathInfoMock.getSelectors())
+          .thenReturn(selectors);
+
+        this.at.init(this.processingContextMock, this.processingComponentConfigurationMock);
+
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(error("Failed to resolve page manager while initializing AMP transformer.")));
+    }
+
+    @Test
+    public void init_pageNull() {
+        String[] selectors = new String[] {"amp"};
+
+        when(this.processingContextMock.getRequest())
+          .thenReturn(this.slingHttpServletRequestMock);
+        when(this.slingHttpServletRequestMock.getResourceResolver())
+          .thenReturn(this.resourceResolverMock);
+        when(this.resourceResolverMock.adaptTo(PageManager.class))
+          .thenReturn(this.pageManagerMock);
+        when(this.resourceResolverMock.adaptTo(ContentPolicyManager.class))
+          .thenReturn(null);
+        when(this.pageManagerMock.getContainingPage(this.slingHttpServletRequestMock.getResource()))
+          .thenReturn(null);
+        when(this.slingHttpServletRequestMock.getRequestPathInfo())
+          .thenReturn(this.requestPathInfoMock);
+        when(this.requestPathInfoMock.getSelectors())
+          .thenReturn(selectors);
+
+        this.at.init(this.processingContextMock, this.processingComponentConfigurationMock);
+
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(error("Failed to resolve page while initializing AMP transformer")));
+    }
+
+    @Test
+    public void contentHandler() throws SAXException {
+        char[] ch = new char[26];
+        int index = 0;
+        for (char c = 'a'; c <= 'z'; c++) {
+            ch[index++] = c;
+        }
+
+        this.at.setContentHandler(this.contentHandlerMock);
+
+        this.at.startDocument();
+        verify(this.contentHandlerMock, times(1)).startDocument();
+        this.at.startElement("uri", "localName", "qName", this.attributesMock);
+        verify(this.contentHandlerMock, times(1)).startElement("uri", "localName", "qName", this.attributesMock);
+        this.at.startPrefixMapping("prefix", "uri");
+        verify(this.contentHandlerMock, times(1)).startPrefixMapping("prefix", "uri");
+        this.at.characters(ch, 0, 5);
+        verify(this.contentHandlerMock, times(1)).characters(ch, 0, 5);
+        this.at.ignorableWhitespace(ch, 3, 15);
+        verify(this.contentHandlerMock, times(1)).ignorableWhitespace(ch, 3, 15);
+        this.at.processingInstruction("target", "data");
+        verify(this.contentHandlerMock, times(1)).processingInstruction("target", "data");
+        this.at.setDocumentLocator(locatorMock);
+        verify(this.contentHandlerMock, times(1)).setDocumentLocator(locatorMock);
+        this.at.skippedEntity("name");
+        verify(this.contentHandlerMock, times(1)).skippedEntity("name");
+        this.at.endPrefixMapping("pre");
+        verify(this.contentHandlerMock, times(1)).endPrefixMapping("pre");
+        this.at.endDocument();
+        verify(this.contentHandlerMock, times(1)).endDocument();
+    }
+
+    @Test
+    public void endElement_ampOnlyHeadlibEmpty() throws SAXException {
+        String[] selectors = new String[] {"amp"};
+        Map<String, Object> map = new HashMap<String, Object>(){{
+            put(AMP_MODE_PROP, "ampOnly");
+        }};
+        this.mapSample = new ValueMapDecorator(map);
+
+        when(this.processingContextMock.getRequest())
+          .thenReturn(this.slingHttpServletRequestMock);
+        when(this.slingHttpServletRequestMock.getResourceResolver())
+          .thenReturn(this.resourceResolverMock);
+        when(this.slingHttpServletRequestMock.getResource())
+          .thenReturn(this.resourceMock);
+        when(this.resourceResolverMock.adaptTo(PageManager.class))
+          .thenReturn(this.pageManagerMock);
+        when(this.resourceResolverMock.adaptTo(ContentPolicyManager.class))
+          .thenReturn(null);
+        when(this.pageManagerMock.getContainingPage(this.resourceMock))
+          .thenReturn(this.pageMock);
+        when(this.pageMock.getProperties())
+          .thenReturn(this.mapSample);
+        when(this.slingHttpServletRequestMock.getRequestPathInfo())
+          .thenReturn(this.requestPathInfoMock);
+        when(this.requestPathInfoMock.getSelectors())
+          .thenReturn(selectors);
+
+        when(this.pageMock.getPath())
+          .thenReturn("/path/to/testing/page");
+
+        when(this.cfgMock.getHeadlibName())
+          .thenReturn("");
+
+        this.at.init(this.processingContextMock, this.processingComponentConfigurationMock);
+        this.at.setContentHandler(this.contentHandlerMock);
+        this.at.endElement("uri", "head", "qName");
+
+        verify(this.contentHandlerMock, times(1)).endElement("uri", "head", "qName");
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(error("Headlib name not defined. Failed to aggregate AMP component js.")));
+    }
+
+    @Test
+    public void endElement_pairedAmpHeadlibNameEmpty() throws SAXException {
+        String[] selectors = new String[] {"amp"};
+        Map<String, Object> map = new HashMap<String, Object>(){{
+            put(AMP_MODE_PROP, "pairedAmp");
+        }};
+        this.mapSample = new ValueMapDecorator(map);
+
+        when(this.processingContextMock.getRequest())
+          .thenReturn(this.slingHttpServletRequestMock);
+        when(this.slingHttpServletRequestMock.getResourceResolver())
+          .thenReturn(this.resourceResolverMock);
+        when(this.slingHttpServletRequestMock.getResource())
+          .thenReturn(this.resourceMock);
+        when(this.resourceResolverMock.adaptTo(PageManager.class))
+          .thenReturn(this.pageManagerMock);
+        when(this.resourceResolverMock.adaptTo(ContentPolicyManager.class))
+          .thenReturn(null);
+        when(this.pageManagerMock.getContainingPage(this.resourceMock))
+          .thenReturn(this.pageMock);
+        when(this.pageMock.getProperties())
+          .thenReturn(this.mapSample);
+        when(this.slingHttpServletRequestMock.getRequestPathInfo())
+          .thenReturn(this.requestPathInfoMock);
+        when(this.requestPathInfoMock.getSelectors())
+          .thenReturn(selectors);
+
+        when(this.pageMock.getPath())
+          .thenReturn("/path/to/testing/page");
+
+        when(this.cfgMock.getHeadlibName())
+          .thenReturn("");
+
+        this.at.init(this.processingContextMock, this.processingComponentConfigurationMock);
+        this.at.setContentHandler(this.contentHandlerMock);
+        this.at.endElement("uri", "head", "qName");
+
+        verify(this.contentHandlerMock, times(1)).endElement("uri", "head", "qName");
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(error("Headlib name not defined. Failed to aggregate AMP component js.")));
+    }
+
+    @Test
+    public void endElement_pairedAmpHeadlibResourceAlwaysNull() throws SAXException, LoginException {
+        String[] selectors = new String[] {"amp"};
+        Map<String, Object> map = new HashMap<String, Object>(){{
+            put(AMP_MODE_PROP, "pairedAmp");
+        }};
+        this.mapSample = new ValueMapDecorator(map);
+
+        when(this.processingContextMock.getRequest())
+          .thenReturn(this.slingHttpServletRequestMock);
+
+        when(this.slingHttpServletRequestMock.getResourceResolver())
+          .thenReturn(this.resourceResolverMock);
+        when(this.slingHttpServletRequestMock.getResource())
+          .thenReturn(this.resourceMock);
+        when(this.resourceResolverMock.adaptTo(PageManager.class))
+          .thenReturn(this.pageManagerMock);
+        when(this.resourceResolverMock.adaptTo(ContentPolicyManager.class))
+          .thenReturn(null);
+        when(this.pageManagerMock.getContainingPage(this.resourceMock))
+          .thenReturn(this.pageMock);
+        when(this.pageMock.getProperties())
+          .thenReturn(this.mapSample);
+        when(this.slingHttpServletRequestMock.getRequestPathInfo())
+          .thenReturn(this.requestPathInfoMock);
+        when(this.requestPathInfoMock.getSelectors())
+          .thenReturn(selectors);
+
+        when(this.pageMock.getPath())
+          .thenReturn("/path/to/testing/page");
+
+        when(this.cfgMock.getHeadlibName())
+          .thenReturn("customheadlibs.amp.html");
+        when(this.cfgMock.getHeadlibResourceTypeRegex())
+          .thenReturn(this.resourceTypeRegexSample);
+        when(this.resourceMock.getResourceType())
+          .thenReturn("/fakeType");
+        when(this.resourceResolverFactoryMock.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, Utils.CLIENTLIB_SUBSERVICE)))
+          .thenReturn(this.resourceResolverMock);
+        when(this.resourceResolverMock.getResource("/fakeType/customheadlibs.amp.html/" + JcrConstants.JCR_CONTENT))
+          .thenReturn(null);
+        when(this.resourceResolverMock.getResource("/fakeType"))
+          .thenReturn(null);
+
+        this.at.init(this.processingContextMock, this.processingComponentConfigurationMock);
+        this.at.setContentHandler(this.contentHandlerMock);
+        this.at.endElement("uri", "head", "qName");
+
+        verify(this.contentHandlerMock, times(1)).endElement("uri", "head", "qName");
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(trace("No custom headlib for resource type {}.", "/fakeType")));
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(debug("Can't access resource from resource type {}.", "/fakeType")));
+    }
+
+    @Test
+    public void endElement_pairedAmpHeadlibResourceSupertypeNull() throws SAXException, LoginException {
+        String[] selectors = new String[] {"amp"};
+        Map<String, Object> map = new HashMap<String, Object>(){{
+            put(AMP_MODE_PROP, "pairedAmp");
+        }};
+        this.mapSample = new ValueMapDecorator(map);
+
+        when(this.processingContextMock.getRequest())
+          .thenReturn(this.slingHttpServletRequestMock);
+
+        when(this.slingHttpServletRequestMock.getResourceResolver())
+          .thenReturn(this.resourceResolverMock);
+        when(this.slingHttpServletRequestMock.getResource())
+          .thenReturn(this.resourceMock);
+        when(this.resourceResolverMock.adaptTo(PageManager.class))
+          .thenReturn(this.pageManagerMock);
+        when(this.resourceResolverMock.adaptTo(ContentPolicyManager.class))
+          .thenReturn(null);
+        when(this.pageManagerMock.getContainingPage(this.resourceMock))
+          .thenReturn(this.pageMock);
+        when(this.pageMock.getProperties())
+          .thenReturn(this.mapSample);
+        when(this.slingHttpServletRequestMock.getRequestPathInfo())
+          .thenReturn(this.requestPathInfoMock);
+        when(this.requestPathInfoMock.getSelectors())
+          .thenReturn(selectors);
+
+        when(this.pageMock.getPath())
+          .thenReturn("/path/to/testing/page");
+
+        when(this.cfgMock.getHeadlibName())
+          .thenReturn("customheadlibs.amp.html");
+        when(this.cfgMock.getHeadlibResourceTypeRegex())
+          .thenReturn(this.resourceTypeRegexSample);
+        when(this.resourceMock.getResourceType())
+          .thenReturn("/fakeType");
+        when(this.resourceResolverFactoryMock.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, Utils.CLIENTLIB_SUBSERVICE)))
+          .thenReturn(this.resourceResolverMock);
+        when(this.resourceResolverMock.getResource("/fakeType/customheadlibs.amp.html/" + JcrConstants.JCR_CONTENT))
+          .thenReturn(null);
+        when(this.resourceResolverMock.getResource("/fakeType"))
+          .thenReturn(this.coreResourceMock);
+        when(this.coreResourceMock.getResourceSuperType())
+          .thenReturn(null);
+
+        this.at.init(this.processingContextMock, this.processingComponentConfigurationMock);
+        this.at.setContentHandler(this.contentHandlerMock);
+        this.at.endElement("uri", "head", "qName");
+
+        verify(this.contentHandlerMock, times(1)).endElement("uri", "head", "qName");
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(trace("No custom headlib for resource type {}.", "/fakeType")));
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(trace("No resource superType from resource type {}.", "/fakeType")));
+    }
+
+    @Test
+    public void endElement_pairedAmpHeadlibResourceSupertypeExistsInputStreamNull() throws SAXException, LoginException {
+        String[] selectors = new String[] {"amp"};
+        Map<String, Object> map = new HashMap<String, Object>(){{
+            put(AMP_MODE_PROP, "pairedAmp");
+        }};
+        this.mapSample = new ValueMapDecorator(map);
+
+        when(this.processingContextMock.getRequest())
+          .thenReturn(this.slingHttpServletRequestMock);
+
+        when(this.slingHttpServletRequestMock.getResourceResolver())
+          .thenReturn(this.resourceResolverMock);
+        when(this.slingHttpServletRequestMock.getResource())
+          .thenReturn(this.resourceMock);
+        when(this.resourceResolverMock.adaptTo(PageManager.class))
+          .thenReturn(this.pageManagerMock);
+        when(this.resourceResolverMock.adaptTo(ContentPolicyManager.class))
+          .thenReturn(null);
+        when(this.pageManagerMock.getContainingPage(this.resourceMock))
+          .thenReturn(this.pageMock);
+        when(this.pageMock.getProperties())
+          .thenReturn(this.mapSample);
+        when(this.slingHttpServletRequestMock.getRequestPathInfo())
+          .thenReturn(this.requestPathInfoMock);
+        when(this.requestPathInfoMock.getSelectors())
+          .thenReturn(selectors);
+
+        when(this.pageMock.getPath())
+          .thenReturn("/path/to/testing/page");
+
+        when(this.cfgMock.getHeadlibName())
+          .thenReturn("customheadlibs.amp.html");
+        when(this.cfgMock.getHeadlibResourceTypeRegex())
+          .thenReturn(this.resourceTypeRegexSample);
+        when(this.resourceMock.getResourceType())
+          .thenReturn("/fakeType");
+        when(this.resourceResolverFactoryMock.getServiceResourceResolver(Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, Utils.CLIENTLIB_SUBSERVICE)))
+          .thenReturn(this.resourceResolverMock);
+        when(this.resourceResolverMock.getResource("/fakeType/customheadlibs.amp.html/" + JcrConstants.JCR_CONTENT))
+          .thenReturn(null);
+        when(this.resourceResolverMock.getResource("/fakeType"))
+          .thenReturn(this.coreResourceMock);
+        when(this.coreResourceMock.getResourceSuperType())
+          .thenReturn("/path/to/superType");
+        when(this.resourceResolverMock.getResource("/path/to/superType/customheadlibs.amp.html/" + JcrConstants.JCR_CONTENT))
+          .thenReturn(this.supertypeResourceMock);
+        when(this.supertypeResourceMock.adaptTo(InputStream.class))
+          .thenReturn(null);
+
+        this.at.init(this.processingContextMock, this.processingComponentConfigurationMock);
+        this.at.setContentHandler(this.contentHandlerMock);
+        this.at.endElement("uri", "head", "qName");
+
+        verify(this.contentHandlerMock, times(1)).endElement("uri", "head", "qName");
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(trace("No custom headlib for resource type {}.", "/fakeType")));
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(debug("Failed to read input stream from {}.", "/fakeType/customheadlibs.amp.html/" + JcrConstants.JCR_CONTENT)));
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpUtilTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpUtilTest.java
@@ -1,0 +1,177 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2019 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.services.amp;
+
+import org.mockito.Mockito;
+import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
+import static uk.org.lidalia.slf4jtest.LoggingEvent.debug;
+import static uk.org.lidalia.slf4jtest.LoggingEvent.trace;
+
+import com.adobe.cq.wcm.core.components.internal.services.amp.AmpUtil;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.Resource;
+import com.adobe.cq.commerce.common.ValueMapDecorator;
+import org.apache.sling.api.resource.ValueMap;
+import java.util.HashMap;
+import java.util.Map;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.policies.ContentPolicyManager;
+import com.day.cq.wcm.api.policies.ContentPolicy;
+
+public class AmpUtilTest {
+    private static final String AMP_MODE_PROP = "ampMode";
+
+    private TestLogger testLogger;
+
+    private PageManager pageManagerMock;
+    private Page pageMock;
+    private SlingHttpServletRequest slingHttpServletRequestMock;
+    private ResourceResolver resourceResolverMock;
+    private Resource resourceMock;
+    private ContentPolicyManager contentPolicyManagerMock;
+    private ContentPolicy contentPolicyMock;
+
+    private ValueMap mapSample;
+
+    @BeforeEach
+    void setUp() {
+        this.testLogger = TestLoggerFactory.getTestLogger(AmpUtil.class);
+
+        this.pageManagerMock = Mockito.mock(PageManager.class);
+        this.pageMock = Mockito.mock(Page.class);
+        this.slingHttpServletRequestMock = Mockito.mock(SlingHttpServletRequest.class);
+        this.resourceResolverMock = Mockito.mock(ResourceResolver.class);
+        this.resourceMock = Mockito.mock(Resource.class);
+        this.contentPolicyManagerMock = Mockito.mock(ContentPolicyManager.class);
+        this.contentPolicyMock = Mockito.mock(ContentPolicy.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TestLoggerFactory.clear();
+    }
+
+    @Test
+    public void getAmpMode_pageManagerNull() {
+        when(this.slingHttpServletRequestMock.getResourceResolver())
+          .thenReturn(this.resourceResolverMock);
+        when(this.resourceResolverMock.adaptTo(PageManager.class))
+          .thenReturn(null);
+        when(this.resourceResolverMock.adaptTo(ContentPolicyManager.class))
+          .thenReturn(null);
+
+        String output = AmpUtil.getAmpMode(this.slingHttpServletRequestMock);
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(debug("Can't resolve page manager. Falling back to content policy AMP mode.")));
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(trace("Policy manager is null. Unable to read policy property.")));
+        assertEquals("", output);
+    }
+
+    @Test
+    public void getAmpMode_pageNull() {
+        when(this.slingHttpServletRequestMock.getResourceResolver())
+          .thenReturn(this.resourceResolverMock);
+        when(this.slingHttpServletRequestMock.getResource())
+          .thenReturn(this.resourceMock);
+        when(this.resourceResolverMock.adaptTo(PageManager.class))
+          .thenReturn(this.pageManagerMock);
+        when(this.resourceResolverMock.adaptTo(ContentPolicyManager.class))
+          .thenReturn(null);
+        when(this.pageManagerMock.getContainingPage(this.slingHttpServletRequestMock.getResource()))
+          .thenReturn(null);
+
+        String output = AmpUtil.getAmpMode(this.slingHttpServletRequestMock);
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(trace("Policy manager is null. Unable to read policy property.")));
+        assertEquals("", output);
+    }
+
+    @Test
+    public void getAmpMode_pageExists() {
+        Map<String, Object> map = new HashMap<String, Object>(){{
+            put(AMP_MODE_PROP, "ampOnly");
+        }};
+        this.mapSample = new ValueMapDecorator(map);
+
+        when(this.slingHttpServletRequestMock.getResourceResolver())
+          .thenReturn(this.resourceResolverMock);
+        when(this.slingHttpServletRequestMock.getResource())
+          .thenReturn(this.resourceMock);
+        when(this.resourceResolverMock.adaptTo(PageManager.class))
+          .thenReturn(this.pageManagerMock);
+        when(this.pageManagerMock.getContainingPage(this.resourceMock))
+          .thenReturn(this.pageMock);
+        when(this.pageMock.getProperties())
+          .thenReturn(this.mapSample);
+
+        assertEquals("ampOnly", AmpUtil.getAmpMode(this.slingHttpServletRequestMock));
+    }
+
+    @Test
+    public void getPolicyProperty_contentPolicyNull() {
+        when(this.slingHttpServletRequestMock.getResourceResolver())
+          .thenReturn(this.resourceResolverMock);
+        when(this.slingHttpServletRequestMock.getResource())
+          .thenReturn(this.resourceMock);
+        when(this.resourceResolverMock.adaptTo(PageManager.class))
+          .thenReturn(this.pageManagerMock);
+        when(this.resourceResolverMock.adaptTo(ContentPolicyManager.class))
+          .thenReturn(this.contentPolicyManagerMock);
+        when(this.pageManagerMock.getContainingPage(this.slingHttpServletRequestMock.getResource()))
+          .thenReturn(null);
+        when(this.contentPolicyManagerMock.getPolicy(this.resourceMock))
+          .thenReturn(null);
+
+        String output = AmpUtil.getAmpMode(this.slingHttpServletRequestMock);
+        assertThat(this.testLogger.getLoggingEvents(), hasItem(trace("Content policy is null. Unable to read policy property.")));
+        assertEquals("", output);
+    }
+
+    @Test
+    public void getPolicyProperty_contentPolicyExists() {
+        Map<String, Object> map = new HashMap<String, Object>(){{
+            put(AMP_MODE_PROP, "inheritPageTemplate");
+        }};
+        this.mapSample = new ValueMapDecorator(map);
+
+        when(this.slingHttpServletRequestMock.getResourceResolver())
+          .thenReturn(this.resourceResolverMock);
+        when(this.slingHttpServletRequestMock.getResource())
+          .thenReturn(this.resourceMock);
+        when(this.resourceResolverMock.adaptTo(PageManager.class))
+          .thenReturn(this.pageManagerMock);
+        when(this.resourceResolverMock.adaptTo(ContentPolicyManager.class))
+          .thenReturn(this.contentPolicyManagerMock);
+        when(this.pageManagerMock.getContainingPage(this.slingHttpServletRequestMock.getResource()))
+          .thenReturn(null);
+        when(this.contentPolicyManagerMock.getPolicy(this.resourceMock))
+          .thenReturn(this.contentPolicyMock);
+        when(this.contentPolicyMock.getProperties())
+          .thenReturn(this.mapSample);
+
+        assertEquals("inheritPageTemplate", AmpUtil.getAmpMode(this.slingHttpServletRequestMock));
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpUtilTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/services/amp/AmpUtilTest.java
@@ -15,7 +15,9 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.services.amp;
 
-import org.mockito.Mockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.MockitoAnnotations.initMocks;
 import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
@@ -48,12 +50,19 @@ public class AmpUtilTest {
 
     private TestLogger testLogger;
 
+    @Mock
     private PageManager pageManagerMock;
+    @Mock
     private Page pageMock;
+    @Mock
     private SlingHttpServletRequest slingHttpServletRequestMock;
+    @Mock
     private ResourceResolver resourceResolverMock;
+    @Mock
     private Resource resourceMock;
+    @Mock
     private ContentPolicyManager contentPolicyManagerMock;
+    @Mock
     private ContentPolicy contentPolicyMock;
 
     private ValueMap mapSample;
@@ -62,13 +71,7 @@ public class AmpUtilTest {
     void setUp() {
         this.testLogger = TestLoggerFactory.getTestLogger(AmpUtil.class);
 
-        this.pageManagerMock = Mockito.mock(PageManager.class);
-        this.pageMock = Mockito.mock(Page.class);
-        this.slingHttpServletRequestMock = Mockito.mock(SlingHttpServletRequest.class);
-        this.resourceResolverMock = Mockito.mock(ResourceResolver.class);
-        this.resourceMock = Mockito.mock(Resource.class);
-        this.contentPolicyManagerMock = Mockito.mock(ContentPolicyManager.class);
-        this.contentPolicyMock = Mockito.mock(ContentPolicy.class);
+        initMocks(this);
     }
 
     @AfterEach

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -181,7 +181,7 @@
                 <plugin>
                     <groupId>org.apache.jackrabbit</groupId>
                     <artifactId>filevault-package-maven-plugin</artifactId>
-                    <version>1.0.4</version>
+                    <version>1.0.0</version>
                     <configuration>
                         <failOnMissingEmbed>true</failOnMissingEmbed>
                         <filterSource>${project.basedir}/src/content/META-INF/vault/filter.xml</filterSource>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -181,7 +181,7 @@
                 <plugin>
                     <groupId>org.apache.jackrabbit</groupId>
                     <artifactId>filevault-package-maven-plugin</artifactId>
-                    <version>1.0.0</version>
+                    <version>1.0.4</version>
                     <configuration>
                         <failOnMissingEmbed>true</failOnMissingEmbed>
                         <filterSource>${project.basedir}/src/content/META-INF/vault/filter.xml</filterSource>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `AMP-41` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      | Yes
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
This PR adds unit tests for newest java classes to solve the code coverage error thrown when `mvn clean install -PautoInstallSinglePackage` command is executed.

Some minor changes were made in some of the classes in order to make them testable.

Result:
![image](https://user-images.githubusercontent.com/57115670/68632889-93979d00-04b5-11ea-8fbf-317366a95ba7.png)
