### PR TITLE
Feature/amp/amp 50 fix component reference Fix

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/amp.html
@@ -29,7 +29,7 @@
       delay="${carousel.delay}"
       height="200">
         <div data-sly-repeat.item="${carousel.items}"
-            data-sly-resource="${item.name @ decorationTagName='div'}"
+            data-sly-resource="${item.name @ decorationTagName='div', selectors='amp'}"
             class="cmp-carousel__item${itemList.first ? ' cmp-carousel__item--active' : ''}"
             role="tabpanel"
             aria-label="${'Slide {0} of {1}' @ format=[itemList.count, carousel.items.size], i18n}"

--- a/examples/src/content/jcr_root/apps/core-components-examples/components/accordion/.content.xml
+++ b/examples/src/content/jcr_root/apps/core-components-examples/components/accordion/.content.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2019 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:description="Accordion Component for the Core Components Library"
+    jcr:primaryType="cq:Component"
+    jcr:title="Accordion"
+    sling:resourceSuperType="core/wcm/components/accordion/v1/accordion"
+    componentGroup="Core Components Examples"/>

--- a/examples/src/content/jcr_root/apps/core-components-examples/components/carousel/.content.xml
+++ b/examples/src/content/jcr_root/apps/core-components-examples/components/carousel/.content.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2019 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:description="Carousel Component for the Core Components Library"
+    jcr:primaryType="cq:Component"
+    jcr:title="Carousel"
+    sling:resourceSuperType="core/wcm/components/carousel/v1/carousel"
+    componentGroup="Core Components Examples"/>

--- a/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/.content.xml
+++ b/examples/src/content/jcr_root/apps/core-components-examples/components/tabs/.content.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2019 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:description="Tabs Component for the Core Components Library"
+          jcr:primaryType="cq:Component"
+          jcr:title="Tabs"
+          sling:resourceSuperType="core/wcm/components/tabs/v1/tabs"
+          componentGroup="Core Components Examples"/>

--- a/examples/src/content/jcr_root/content/core-components-examples/library/accordion/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/accordion/.content.xml
@@ -49,7 +49,7 @@
                     actionsEnabled="false"
                     descriptionFromPage="false"
                     fileReference="/content/dam/core-components-examples/library/github-logo.svg"
-                    linkURL="https://www.adobe.com/go/aem_cmp_tech_accordion_v1"
+                    linkURL="https://github.com/adobe/aem-core-wcm-components/blob/master/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion"
                     textIsRich="true"
                     titleFromPage="false"/>
                 <teaser_660608423
@@ -114,7 +114,7 @@
                             jcr:lastModified="{Date}2018-12-07T13:11:51.267+01:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/accordion/v1/accordion">
+                            sling:resourceType="core-components-examples/components/accordion">
                             <item_021105873
                                 cq:panelTitle="Item 1"
                                 jcr:primaryType="nt:unstructured"
@@ -133,7 +133,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -187,7 +187,7 @@
                             jcr:lastModified="{Date}2018-12-07T13:12:10.691+01:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/accordion/v1/accordion">
+                            sling:resourceType="core-components-examples/components/accordion">
                             <item_617130698
                                 cq:panelTitle="Item 1"
                                 jcr:primaryType="nt:unstructured"
@@ -297,7 +297,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -351,7 +351,7 @@
                             jcr:lastModified="{Date}2018-12-07T13:12:10.691+01:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/accordion/v1/accordion"
+                            sling:resourceType="core-components-examples/components/accordion"
                             expandedItems="[item_1]">
                             <item_1
                                 cq:panelTitle="Item 1"
@@ -390,7 +390,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -444,7 +444,7 @@
                             jcr:lastModified="{Date}2018-12-07T13:12:10.691+01:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/accordion/v1/accordion"
+                            sling:resourceType="core-components-examples/components/accordion"
                             expandedItems="[item_1,item_2,item_3]">
                             <item_1
                                 cq:panelTitle="Item 1"
@@ -483,7 +483,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -537,7 +537,7 @@
                             jcr:lastModified="{Date}2018-12-07T13:12:10.691+01:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/accordion/v1/accordion"
+                            sling:resourceType="core-components-examples/components/accordion"
                             expandedItems="[item_1]"
                             singleExpansion="{Boolean}true">
                             <item_1
@@ -577,7 +577,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -631,7 +631,7 @@
                             jcr:lastModified="{Date}2018-12-07T13:25:41.269+01:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/accordion/v1/accordion">
+                            sling:resourceType="core-components-examples/components/accordion">
                             <item_215402425
                                 cq:panelTitle="Item 1"
                                 jcr:primaryType="nt:unstructured"
@@ -643,7 +643,7 @@
                                     jcr:lastModified="{Date}2019-01-22T12:51:03.767+01:00"
                                     jcr:lastModifiedBy="admin"
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="core/wcm/components/accordion/v1/accordion">
+                                    sling:resourceType="core-components-examples/components/accordion">
                                     <item_468781096
                                         cq:panelTitle="Item 1.1"
                                         jcr:primaryType="nt:unstructured"
@@ -672,7 +672,7 @@
                                     jcr:lastModified="{Date}2019-01-22T12:51:24.126+01:00"
                                     jcr:lastModifiedBy="admin"
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="core/wcm/components/accordion/v1/accordion">
+                                    sling:resourceType="core-components-examples/components/accordion">
                                     <item_645266587
                                         cq:panelTitle="Item 2.1"
                                         jcr:primaryType="nt:unstructured"
@@ -701,7 +701,7 @@
                                     jcr:lastModified="{Date}2019-01-22T12:51:36.077+01:00"
                                     jcr:lastModifiedBy="admin"
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="core/wcm/components/accordion/v1/accordion">
+                                    sling:resourceType="core-components-examples/components/accordion">
                                     <item_716487435
                                         cq:panelTitle="Item 3.1"
                                         jcr:primaryType="nt:unstructured"
@@ -723,7 +723,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/breadcrumb/hidden/level-1/level-2/breadcrumb/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/breadcrumb/hidden/level-1/level-2/breadcrumb/.content.xml
@@ -121,7 +121,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -181,7 +181,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -241,7 +241,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -301,7 +301,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/button/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/button/.content.xml
@@ -118,7 +118,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -177,7 +177,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -236,7 +236,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/carousel/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/carousel/.content.xml
@@ -49,7 +49,7 @@
                     actionsEnabled="false"
                     descriptionFromPage="false"
                     fileReference="/content/dam/core-components-examples/library/github-logo.svg"
-                    linkURL="https://www.adobe.com/go/aem_cmp_tech_carousel_v1"
+                    linkURL="https://github.com/adobe/aem-core-wcm-components/blob/master/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel"
                     textIsRich="true"
                     titleFromPage="false"/>
                 <teaser_556024830
@@ -113,7 +113,7 @@
                             jcr:lastModified="{Date}2019-01-15T14:12:32.561+01:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/carousel/v1/carousel"
+                            sling:resourceType="core-components-examples/components/carousel"
                             autopauseDisabled="false"
                             autoplay="false"
                             delay="5000">
@@ -150,7 +150,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -203,7 +203,7 @@
                             jcr:lastModified="{Date}2019-01-22T13:37:48.966+01:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/carousel/v1/carousel"
+                            sling:resourceType="core-components-examples/components/carousel"
                             autopauseDisabled="false"
                             autoplay="false"
                             delay="5000">
@@ -259,7 +259,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -312,7 +312,7 @@
                             jcr:lastModified="{Date}2019-01-14T21:10:38.710+01:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/carousel/v1/carousel"
+                            sling:resourceType="core-components-examples/components/carousel"
                             autopauseDisabled="false"
                             autoplay="true"
                             delay="5000">
@@ -344,7 +344,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -397,7 +397,7 @@
                             jcr:lastModified="{Date}2019-01-14T21:10:54.093+01:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/carousel/v1/carousel"
+                            sling:resourceType="core-components-examples/components/carousel"
                             autopauseDisabled="true"
                             autoplay="true"
                             delay="5000">
@@ -429,7 +429,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/container/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/container/.content.xml
@@ -104,7 +104,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -180,7 +180,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -242,7 +242,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -304,7 +304,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -423,7 +423,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/content-fragment-list/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/content-fragment-list/.content.xml
@@ -120,7 +120,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -180,7 +180,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -241,7 +241,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -301,7 +301,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/content-fragment/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/content-fragment/.content.xml
@@ -127,7 +127,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -189,7 +189,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -250,7 +250,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -312,7 +312,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/download/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/download/.content.xml
@@ -127,7 +127,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -191,7 +191,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -256,7 +256,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -320,7 +320,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/embed/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/embed/.content.xml
@@ -118,7 +118,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -174,7 +174,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -231,7 +231,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -286,7 +286,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/experience-fragment/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/experience-fragment/.content.xml
@@ -119,7 +119,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/image/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/image/.content.xml
@@ -122,7 +122,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -184,7 +184,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -247,7 +247,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -309,7 +309,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/language-navigation/language-structure/de/de/language-navigation/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/language-navigation/language-structure/de/de/language-navigation/.content.xml
@@ -120,7 +120,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/language-navigation/language-structure/fr/fr/language-navigation/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/language-navigation/language-structure/fr/fr/language-navigation/.content.xml
@@ -120,7 +120,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/language-navigation/language-structure/us/en/language-navigation/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/language-navigation/language-structure/us/en/language-navigation/.content.xml
@@ -119,7 +119,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/language-navigation/language-structure/us/es/language-navigation/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/language-navigation/language-structure/us/es/language-navigation/.content.xml
@@ -120,7 +120,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/list/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/list/.content.xml
@@ -124,7 +124,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -189,7 +189,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -255,7 +255,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -321,7 +321,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -386,7 +386,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -451,7 +451,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -515,7 +515,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/navigation/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/navigation/.content.xml
@@ -113,7 +113,7 @@
                             jcr:lastModified="{Date}2019-05-21T18:59:35.605+03:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/navigation/v1/navigation"
+                            sling:resourceType="core-components-examples/components/navigation"
                             collectAllPages="true"
                             hideCurrent="false"
                             navigationRoot="/content/core-components-examples"
@@ -123,7 +123,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -176,7 +176,7 @@
                             jcr:lastModified="{Date}2019-05-21T19:07:03.606+03:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/navigation/v1/navigation"
+                            sling:resourceType="core-components-examples/components/navigation"
                             collectAllPages="true"
                             hideCurrent="false"
                             navigationRoot="/content/core-components-examples"
@@ -186,7 +186,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -238,7 +238,7 @@
                             jcr:lastModified="{Date}2019-05-21T19:28:11.709+03:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/navigation/v1/navigation"
+                            sling:resourceType="core-components-examples/components/navigation"
                             collectAllPages="false"
                             hideCurrent="false"
                             navigationRoot="/content/core-components-examples"
@@ -249,7 +249,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/separator/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/separator/.content.xml
@@ -119,7 +119,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/social-sharing/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/social-sharing/.content.xml
@@ -118,7 +118,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/tabs/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/tabs/.content.xml
@@ -49,7 +49,7 @@
                     actionsEnabled="false"
                     descriptionFromPage="false"
                     fileReference="/content/dam/core-components-examples/library/github-logo.svg"
-                    linkURL="https://www.adobe.com/go/aem_cmp_tech_tabs_v1"
+                    linkURL="https://github.com/adobe/aem-core-wcm-components/blob/master/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs"
                     textIsRich="true"
                     titleFromPage="false"/>
                 <teaser_556024830
@@ -113,7 +113,7 @@
                             jcr:lastModified="{Date}2018-12-07T13:11:51.267+01:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                            sling:resourceType="core-components-examples/components/tabs">
                             <item_1
                                 cq:panelTitle="Tab 1"
                                 jcr:primaryType="nt:unstructured"
@@ -132,7 +132,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -185,7 +185,7 @@
                             jcr:lastModified="{Date}2018-12-07T13:12:10.691+01:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                            sling:resourceType="core-components-examples/components/tabs">
                             <item_1
                                 cq:panelTitle="Tab 1"
                                 jcr:primaryType="nt:unstructured"
@@ -259,7 +259,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -312,7 +312,7 @@
                             jcr:lastModified="{Date}2018-12-07T13:15:45.655+01:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/tabs/v1/tabs"
+                            sling:resourceType="core-components-examples/components/tabs"
                             activeItem="item_1544184936449">
                             <item_1
                                 cq:panelTitle="Tab 1"
@@ -333,7 +333,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -386,7 +386,7 @@
                             jcr:lastModified="{Date}2018-12-07T13:25:41.269+01:00"
                             jcr:lastModifiedBy="admin"
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                            sling:resourceType="core-components-examples/components/tabs">
                             <item_1
                                 cq:panelTitle="Tab 1"
                                 jcr:primaryType="nt:unstructured"
@@ -398,7 +398,7 @@
                                     jcr:lastModified="{Date}2019-01-22T12:51:03.767+01:00"
                                     jcr:lastModifiedBy="admin"
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                                    sling:resourceType="core-components-examples/components/tabs">
                                     <item_1
                                         cq:panelTitle="Tab 1.1"
                                         jcr:primaryType="nt:unstructured"
@@ -427,7 +427,7 @@
                                     jcr:lastModified="{Date}2019-01-22T12:51:24.126+01:00"
                                     jcr:lastModifiedBy="admin"
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                                    sling:resourceType="core-components-examples/components/tabs">
                                     <item_1
                                         cq:panelTitle="Tab 2.1"
                                         jcr:primaryType="nt:unstructured"
@@ -456,7 +456,7 @@
                                     jcr:lastModified="{Date}2019-01-22T12:51:36.077+01:00"
                                     jcr:lastModifiedBy="admin"
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                                    sling:resourceType="core-components-examples/components/tabs">
                                     <item_1
                                         cq:panelTitle="Tab 3.1"
                                         jcr:primaryType="nt:unstructured"
@@ -478,7 +478,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/teaser/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/teaser/.content.xml
@@ -124,7 +124,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -188,7 +188,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -253,7 +253,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -324,7 +324,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -399,7 +399,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -462,7 +462,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/text/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/text/.content.xml
@@ -120,7 +120,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -179,7 +179,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -238,7 +238,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -297,7 +297,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"

--- a/examples/src/content/jcr_root/content/core-components-examples/library/title/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/title/.content.xml
@@ -117,7 +117,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -175,7 +175,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -234,7 +234,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"
@@ -293,7 +293,7 @@
                     </component>
                     <info
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/tabs/v1/tabs">
+                        sling:resourceType="core-components-examples/components/tabs">
                         <properties
                             cq:panelTitle="Properties"
                             jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | AMP-50
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
This PR will fix a few things that were happening due to the fact that the sling resolution was simply not happening for some components like carousel, accordion, tabs, and navigation. aside from fixing the missing `.content.xml` files for these local impl. components. this PR modifies the way components are added to the Component Library pages so that they use the local version of the components in order to inherit from the local AMP styles. Ultimately, that was the issue reported in AMP-50: Because styles were using the full HTML based CSS of the component and these were setting `display:none;` for slides greater than #1, `amp-img` was simply not rendering the `img` element. 🤦‍♂ 