### PR TITLE
hide component search on AMP pages

### DIFF
--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-base-amp/styles/base/base.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-base-amp/styles/base/base.less
@@ -72,3 +72,8 @@ a {
     border-color: @cmp-examples-color-gray-700;
     color: @cmp-examples-color-gray-700;
 }
+
+// Home page search form - hidden on AMP pages
+.cmp-examples-form-text--search {
+    display: none;
+}

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-base-amp/styles/base/demo.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-base-amp/styles/base/demo.less
@@ -131,8 +131,3 @@
         }
     }
 }
-
-// Home page search form - hidden on AMP pages
-.cmp-examples-form-text--search {
-    display: none;
-}

--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-base-amp/styles/base/demo.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-base-amp/styles/base/demo.less
@@ -131,3 +131,8 @@
         }
     }
 }
+
+// Home page search form - hidden on AMP pages
+.cmp-examples-form-text--search {
+    display: none;
+}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Yes
| Patch: Bug Fix?          | No
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | No/Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
This hides the search components functionality on the AMP homepage as it is not AMP compliant markup. 