### PR TITLE
Hotfix/amp/turn off amp for some pages

### DIFF
--- a/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-base-amp/styles/base/base.less
+++ b/examples/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-base-amp/styles/base/base.less
@@ -77,3 +77,8 @@ a {
 .cmp-examples-form-text--search {
     display: none;
 }
+
+.cmp-examples-text--no-results {
+    display: none;
+}
+

--- a/examples/src/content/jcr_root/content/core-components-examples/library/embed/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/embed/.content.xml
@@ -9,7 +9,8 @@
         jcr:description="Embed a third-party widget"
         jcr:primaryType="cq:PageContent"
         jcr:title="Embed"
-        sling:resourceType="core-components-examples/components/page">
+        sling:resourceType="core-components-examples/components/page"
+        ampMode="noAmp">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="wcm/foundation/components/responsivegrid">

--- a/examples/src/content/jcr_root/content/core-components-examples/library/experience-fragment/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/experience-fragment/.content.xml
@@ -9,7 +9,8 @@
         jcr:description="Display an experience fragment"
         jcr:primaryType="cq:PageContent"
         jcr:title="Experience Fragment"
-        sling:resourceType="core-components-examples/components/page">
+        sling:resourceType="core-components-examples/components/page"
+        ampMode="noAmp">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="wcm/foundation/components/responsivegrid">

--- a/examples/src/content/jcr_root/content/core-components-examples/library/navigation/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/navigation/.content.xml
@@ -9,7 +9,8 @@
         jcr:description="Display a site navigation menu"
         jcr:primaryType="cq:PageContent"
         jcr:title="Navigation"
-        sling:resourceType="core-components-examples/components/page">
+        sling:resourceType="core-components-examples/components/page"
+        ampMode="noAmp">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="wcm/foundation/components/responsivegrid">

--- a/examples/src/content/jcr_root/content/core-components-examples/library/tabs/.content.xml
+++ b/examples/src/content/jcr_root/content/core-components-examples/library/tabs/.content.xml
@@ -9,7 +9,8 @@
         jcr:description="Switchable content panels"
         jcr:primaryType="cq:PageContent"
         jcr:title="Tabs"
-        sling:resourceType="core-components-examples/components/page">
+        sling:resourceType="core-components-examples/components/page"
+        ampMode="noAmp">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="wcm/foundation/components/responsivegrid">


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
This PR adds the proper JCR property to the following component library example site pages:
- Embed (no AMP support for now)
- Experience Fragment (No AMP support for now)
- Navigation (AMP cannot support multiple amp-sidebar)
- Tabs (AMP cannot support nested amp-selector components)

This also illustrate the mechanism of using the AMP mode override at the page level when needed.
The last commit of this PR hides the “No components found”  that was appearing at the bottom of the Component library homepage when using AMP.
