### PR TITLE
Added exclusion of all the files in the "/extension" folder generated…

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -354,6 +354,8 @@
                             <exclude>**/.github/**</exclude>
                             <!-- Ignore mockito extensions config -->
                             <exclude>**/test/resources/mockito-extensions/*</exclude>
+                            <!-- Ignore generated extension folder -->
+                            <exclude>**/extension/**</exclude>
                         </excludes>
                     </configuration>
                     <executions>


### PR DESCRIPTION
… by the build

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | N/A
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
This PR adds an exclusion for the RAT plugin because it is currently making the build fail when using the `autoInstallPackage` profile.
When using this profile, the build generates an "extension" folder that has some compiled code that is missing proper license definition. This PR will extend the RAT plugin config by excluding 
 the `extension` generated folder from RAT check.