### PR TITLE
Remove Demo Tabs in AMP

### DIFF
--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-base-amp/styles/base/demo.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-base-amp/styles/base/demo.less
@@ -15,7 +15,6 @@
  */
 
 @cmp-examples-demo-border-width: 1*@px;
-@cmp-examples-demo-tab-border-width: 2*@px;
 
 .cmp-examples-demo {
     position: relative;

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-base-amp/styles/base/demo.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-base-amp/styles/base/demo.less
@@ -15,8 +15,6 @@
  */
 
 @cmp-examples-demo-border-width: 1*@px;
-@cmp-examples-demo-info-content-max-lines: 12;
-@cmp-examples-demo-info-content-height: @cmp-examples-demo-info-content-max-lines * (@cmp-examples-font-size-code * @cmp-examples-line-height);
 @cmp-examples-demo-tab-border-width: 2*@px;
 
 .cmp-examples-demo {
@@ -38,96 +36,4 @@
 
 .cmp-examples-demo__component--widthFull {
     width: 100%;
-}
-
-.cmp-examples-demo__info {
-    position: relative;
-    display: none;
-
-    .cmp-tabs__tablist {
-        margin: 0;
-        padding-left: 8*@px;
-        border: @cmp-examples-demo-border-width solid @cmp-examples-color-gray-400;
-        border-width: @cmp-examples-demo-border-width 0 0 0;
-    }
-
-    .cmp-tabs__tab {
-        margin-bottom: -@cmp-examples-demo-border-width;
-        border-bottom: @cmp-examples-demo-tab-border-width solid transparent;
-        padding: @cmp-examples-spacing-3 @cmp-examples-spacing-4 10*@px @cmp-examples-spacing-4;
-
-        font-size: @cmp-examples-font-size-s;
-        line-height: 1.2;
-
-        visibility: hidden;
-        color: @cmp-examples-color-gray-800;
-
-        &:hover,
-        &--active {
-            color: @cmp-examples-color-gray-900;
-        }
-
-        &:focus {
-            outline: none;
-        }
-    }
-}
-
-.cmp-examples-demo__info-actions {
-    position: absolute;
-    top: 0;
-    right: @cmp-examples-spacing-1;
-}
-
-.cmp-examples-demo__info-content {
-    width: auto;
-    height: 0;
-    margin: 0;
-    border-bottom-left-radius: @cmp-examples-border-radius;
-    border-bottom-right-radius: @cmp-examples-border-radius;
-    overflow: auto;
-}
-
-.cmp-examples-demo__properties {
-    margin: 0;
-    line-height: @cmp-examples-line-height;
-
-    font-family: @cmp-examples-font-family-monospace;
-    font-size: @cmp-examples-font-size-code;
-    color: @cmp-examples-color-text-light;
-
-    overflow: auto;
-    white-space: nowrap;
-    list-style-type: decimal;
-
-    .cmp-examples-demo__property-title {
-        padding-left: 1rem;
-        color: @cmp-examples-color-blue-600;
-    }
-
-    .cmp-examples-demo__property-value {
-        color: @cmp-examples-color-green-700;
-    }
-
-    .cmp-examples-demo__property-separator {
-        color: @cmp-examples-color-text;
-    }
-}
-
-.cmp-examples-demo__info--open {
-    .cmp-examples-demo__info-content {
-        height: @cmp-examples-demo-info-content-height;
-    }
-
-    .cmp-tabs__tablist {
-        border-bottom-width: @cmp-examples-demo-border-width;
-    }
-
-    .cmp-tabs__tab {
-        visibility: visible;
-
-        &--active {
-            border-color: @cmp-examples-color-gray-900;
-        }
-    }
 }

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/demo/amp.html
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/demo/amp.html
@@ -17,12 +17,4 @@
     <div class="cmp-examples-demo__top t-cmp-clean t-cmp-clean--light" data-cmp-examples-hook-demo="top">
         <div class="cmp-examples-demo__component cmp-examples-demo__component--widthFull" data-sly-resource="${'component' @ decoration=true}"></div>
     </div>
-    <div class="cmp-examples-demo__info cmp-examples-demo__info--open" data-cmp-examples-hook-demo="info">
-        <div data-sly-resource="${'info' @ decoration=true, wcmmode='disabled'}"></div>
-        <div class="cmp-examples-demo__info-actions">
-            <button class="cmp-examples-button" data-cmp-examples-hook-demo="copyCode" aria-label="${'Copy to clipboard' @ i18n}" data-cmp-examples-tooltip="${'Copy to clipboard' @ i18n}"><i class="cmp-examples-button__icon fas fa-copy"></i></button><!--
-         --><button class="cmp-examples-button" data-cmp-examples-hook-demo="hideCode" aria-label="${'Hide code' @ i18n}" data-cmp-examples-tooltip="${'Hide code' @ i18n}"><i class="cmp-examples-button__icon fas fa-angle-down"></i></button><!--
-         --><button disabled class="cmp-examples-button" data-cmp-examples-hook-demo="showCode" aria-label="${'Show code' @ i18n}" data-cmp-examples-tooltip="${'Show code' @ i18n}"><i class="cmp-examples-button__icon fas fa-angle-up"></i></button>
-        </div>
-    </div>
 </div>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | AMP-52
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
This PR removes the markup and styles related to the Info and tabs in the Component Library's Demo component, only in AMP mode.