### PR TITLE
AMP-55 adding UID for components based on their relative resource path

### DIFF
--- a/AMP.md
+++ b/AMP.md
@@ -1,5 +1,5 @@
 # AMP
-Learn more about how AMP mode can be cotrolled [here](README.md)
+Learn more about how AMP mode can be controlled [here](README.md)
 
 ## Major Technical aspects
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
@@ -20,12 +20,15 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ContainerExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.wcm.core.components.models.Tabs;
+
+import static com.day.cq.commons.jcr.JcrConstants.JCR_CONTENT;
 
 @Model(adaptables = SlingHttpServletRequest.class, adapters = {Tabs.class, ComponentExporter.class, ContainerExporter.class}, resourceType = TabsImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
@@ -38,6 +41,9 @@ public class TabsImpl extends PanelContainerImpl implements Tabs {
 
     @ValueMapValue(injectionStrategy = InjectionStrategy.OPTIONAL)
     private String accessibilityLabel;
+
+    @SlingObject
+    private Resource resource;
 
     private String activeItemName;
 
@@ -55,5 +61,15 @@ public class TabsImpl extends PanelContainerImpl implements Tabs {
     @Override
     public String getAccessibilityLabel() {
         return accessibilityLabel;
+    }
+
+    @Override
+    public String getTabsId() {
+        String resourcePath = resource.getPath();
+        String identifier = resourcePath.substring(resourcePath.indexOf(JCR_CONTENT) + JCR_CONTENT.length());
+        if (resourcePath.startsWith("/conf")) {
+            identifier += "-template";
+        }
+        return identifier.replace("/", "-");
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
@@ -44,4 +44,14 @@ public interface Tabs extends Container {
     default String getAccessibilityLabel() {
         throw new UnsupportedOperationException();
     }
+
+    /**
+     * Returns an unique ID for the tab based on resource path.
+     *
+     * @return an UID for tabs
+     * @since com.adobe.cq.wcm.core.components.models 12.13.0
+     */
+    default String getTabsId() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.12.0")
+@Version("12.13.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/resources/tabs/exporter-tabs1.json
+++ b/bundles/core/src/test/resources/tabs/exporter-tabs1.json
@@ -1,5 +1,6 @@
 {
     "activeItem": "item_2",
+    "tabsId": "-root-responsivegrid-tabs-1",
     ":itemsOrder": [
         "item_1",
         "item_2"

--- a/bundles/core/src/test/resources/tabs/exporter-tabs2.json
+++ b/bundles/core/src/test/resources/tabs/exporter-tabs2.json
@@ -1,5 +1,6 @@
 {
     "activeItem": "item_2",
+    "tabsId": "-root-responsivegrid-tabs-2",
     ":itemsOrder": [
         "item_1",
         "item_2"
@@ -24,6 +25,7 @@
                 },
                 "item_1_2": {
                     "activeItem": "item_1_2_2",
+                    "tabsId": "-root-responsivegrid-tabs-2-item_1-item_1_2",
                     ":itemsOrder": [
                         "item_1_2_1",
                         "item_1_2_2"

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
@@ -29,8 +29,8 @@
 
         <div role="tab"
              option
-             id="tab-item-${tabList.index}"
-             aria-controls="tab-panel-${tabList.index}"
+             id="tab-item${tabs.tabsId}-${tabList.index}"
+             aria-controls="tab-panel${tabs.tabsId}-${tabList.index}"
              class="cmp-tabs__tab"
              data-sly-attribute.selected=${isActive}
              tabindex="${isActive ? '0' : '-1'}"
@@ -38,8 +38,8 @@
              ${tab.title}
         </div>
 
-        <div id="tab-panel-${tabList.index}"
-             aria-labelledby="tab-item-${tabList.index}"
+        <div id="tab-panel${tabs.tabsId}-${tabList.index}"
+             aria-labelledby="tab-item${tabs.tabsId}-${tabList.index}"
              data-sly-resource="${tab.name @ decorationTagName='div'}"
              role="tabpanel"
              tabindex="0"


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes `AMP-55` (amp tab components on the same page with conflicting IDs)
| Patch: Bug Fix?          | Hotfix
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

An ID has been added for each tab and tab panel that is:
`hyphenated current resource path after jcr:content`

There's an additional catch for if the resource is on a template (just to be extra sure the identifiers are unique).
