### PR TITLE
Hotfix/amp/amp 57 image alt fix

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/amp.html
@@ -35,9 +35,10 @@
       <sly data-sly-test.usemap="${'{0}{1}' @ format=['#', resource.path]}"></sly>
       <div class="cmp-image__container">
         <amp-img src="${image.src}" class="cmp-image__image" itemprop="contentUrl" data-cmp-hook-image="image"
-                  data-sly-attribute.usemap="${image.areas ? usemap : ''}"
-                  layout="fill"
-                  alt="${image.alt || true}" title="${image.displayPopupTitle && image.title}"/>
+          alt="${image.alt || true}"
+          data-sly-attribute.usemap="${image.areas ? usemap : ''}"
+          layout="fill"
+          title="${image.displayPopupTitle && image.title}"/>
       </div>                  
 
       <map data-sly-test="${image.areas}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/page/v2/page/amp.html
@@ -38,8 +38,6 @@
 <body class="${page.cssClassNames}">
     <sly data-sly-test="${!isRedirectPage}">
     <sly data-sly-include="body.html"></sly>
-    <!--/* TODO: decide if we want the footer in AMP or not */-->
-    <!--/* TODO: How to handle cloudservices in AMP? */-->
 </sly>
 </body>
 </html>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | AMP-57
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |  No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
This PR simply moves teh `alt` attribute of the `amp-img` element earlier in the list of attributes because amp-validator was complaining that the page was not valid amp when the alt attribute was last and empty. The error was `The attribute 'alt/' may not appear in tag 'amp-img'.` because the element was ending with `... data-cmp-hook-image="image" layout="fill" alt/>`. This change only affects pages rendered in AMP mode.

