### PR TITLE
[AMP] AMP markup review

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/amp.html
@@ -14,24 +14,19 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <amp-accordion data-sly-use.accordion="com.adobe.cq.wcm.core.components.models.Accordion"
-     class="cmp-accordion"
-     data-cmp-is="accordion"
-     data-sly-attribute.expand-single-section="${accordion.singleExpansion}">
-      <section data-sly-test="${accordion.items.size > 0}"
-        data-sly-repeat.item="${accordion.items}"
-        class="cmp-accordion__item"
-        data-cmp-hook-accordion="item"
-        data-sly-attribute.expanded="${item.name in accordion.expandedItems}">
+               data-sly-test="${accordion.items && accordion.items.size > 0}"
+               class="cmp-accordion"
+               expand-single-section="${accordion.singleExpansion}">
+    <section data-sly-repeat.item="${accordion.items}"
+             class="cmp-accordion__item"
+             expanded="${item.name in accordion.expandedItems}">
         <h3 data-sly-element="${accordion.headingElement @ context='elementName'}"
             class="cmp-accordion__header">
             <span class="cmp-accordion__title">${item.title}</span>
             <span class="cmp-accordion__icon"></span>
         </h3>
         <div data-sly-resource="${item.name @ decorationTagName='div'}"
-            data-cmp-hook-accordion="panel"
-            class="cmp-accordion__panel${item.name in accordion.expandedItems ? ' cmp-accordion__panel--expanded' : ' cmp-accordion__panel--hidden'}"
-            role="region"></div>
+             class="cmp-accordion__panel"
+             role="region"></div>
     </section>
-     <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
-        data-sly-test="${(wcmmode.edit || wcmmode.preview) && accordion.items.size < 1}"></sly>
 </amp-accordion>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/amp.html
@@ -13,29 +13,22 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<div data-sly-use.carousel="com.adobe.cq.wcm.core.components.models.Carousel"
-  data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
-  class="cmp-carousel"
-  role="group"
-  aria-label="${carousel.accessibilityLabel}"
-  data-cmp-is="carousel">
-    <amp-carousel data-sly-test="${carousel.items && carousel.items.size > 0}"
-      class="cmp-carousel__content"
-      type="slides"
-      width="350"
-      loop
-      data-sly-attribute.autoplay="${carousel.autoplay}"
-      layout="responsive"
-      delay="${carousel.delay}"
-      height="200">
-        <div data-sly-repeat.item="${carousel.items}"
-            data-sly-resource="${item.name @ decorationTagName='div', selectors='amp'}"
-            class="cmp-carousel__item${itemList.first ? ' cmp-carousel__item--active' : ''}"
-            role="tabpanel"
-            aria-label="${'Slide {0} of {1}' @ format=[itemList.count, carousel.items.size], i18n}"
-            data-cmp-hook-carousel="item">
-        </div>
-    </amp-carousel>
-    <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
-      data-sly-test="${(wcmmode.edit || wcmmode.preview) && carousel.items.size < 1}"></sly>
-</div>
+<amp-carousel data-sly-use.carousel="com.adobe.cq.wcm.core.components.models.Carousel"
+              data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+              data-sly-test="${carousel.items && carousel.items.size > 0}"
+              class="cmp-carousel"
+              role="group"
+              aria-label="${carousel.accessibilityLabel}"
+              type="slides"
+              autoplay="${carousel.autoplay}"
+              delay="${carousel.delay}"
+              loop
+              layout="responsive"
+              width="350"
+              height="200">
+    <div data-sly-repeat.item="${carousel.items}"
+         data-sly-resource="${item.name @ decorationTagName='div', selectors='amp'}"
+         class="cmp-carousel__item"
+         role="tabpanel"
+         aria-label="${'Slide {0} of {1}' @ format=[itemList.count, carousel.items.size], i18n}"></div>
+</amp-carousel>

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/amp.html
@@ -13,38 +13,34 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-
-<section class="cmp-search" role="search"
-  data-sly-use.search="com.adobe.cq.wcm.core.components.models.Search"
-  data-cmp-is="search"
-  data-cmp-min-length="${search.searchTermMinimumLength}"
-  data-cmp-results-size="${search.resultsSize}">
-  <form class="cmp-search__form" data-cmp-hook-search="form"
-    method="get"
-    action="${currentPage.path @ addSelectors=['searchresults'], extension='json', suffix = search.relativePath}"
-    action-xhr="${currentPage.path @ addSelectors=['searchresults'], extension='json', suffix = search.relativePath}"
-    target="_top">
-    <div class="cmp-search__field">
-        <i class="cmp-search__icon" data-cmp-hook-search="icon"></i>
-        <span class="cmp-search__loading-indicator" data-cmp-hook-search="loadingIndicator"></span>
-          
-        <amp-autocomplete filter="substring"
+<section data-sly-use.search="com.adobe.cq.wcm.core.components.models.Search"
+         class="cmp-search"
+         role="search">
+    <form class="cmp-search__form"
+          method="get"
+          action-xhr="${currentPage.path @ addSelectors=['searchresults'], extension='json', suffix = search.relativePath}"
+          target="_top">
+        <amp-autocomplete class="cmp-search__field"
+                          filter="substring"
                           filter-value="title"
                           items="."
-                          class="cmp-search__auto-complete"
                           on="select:AMP.navigateTo(url=event.value)"
                           src="${currentPage.path @ addSelectors=['searchresults'], extension='json', suffix = search.relativePath}?fulltext=*">
-
-          <input class="cmp-search__input" data-cmp-hook-search="input" type="text" name="fulltext" placeholder="${'Search' @ i18n}"
-                role="combobox" aria-autocomplete="list" aria-haspopup="true" aria-invalid="false">
-
-          <!-- Autocomplete results container -->
-          <template type="amp-mustache" id="amp-template-custom">
+            <i class="cmp-search__icon"></i>
+            <input class="cmp-search__input"
+                   type="text"
+                   name="fulltext"
+                   placeholder="${'Search' @ i18n}"
+                   role="combobox"
+                   aria-autocomplete="list"
+                   aria-haspopup="true"
+                   aria-invalid="false">
+            <!--/* search result template */-->
+            <template type="amp-mustache" id="amp-template-custom">
               <div data-value="{{ url }}">
                   <a href="{{ url }}">{{ title }}</a>
               </div>
-          </template>
+            </template>
         </amp-autocomplete>
-    </div>
   </form>
 </section>

--- a/content/src/content/jcr_root/apps/core/wcm/components/sharing/v1/sharing/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/sharing/v1/sharing/amp.html
@@ -13,14 +13,12 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<sly data-sly-use.template="core/wcm/components/commons/v1/templates.html"
-     data-sly-use.socialMedia="com.adobe.cq.wcm.core.components.models.SocialMediaHelper"
+<sly data-sly-use.socialMedia="com.adobe.cq.wcm.core.components.models.SocialMediaHelper"
+     data-sly-use.template="core/wcm/components/commons/v1/templates.html"
      data-sly-call="${template.placeholder @ isEmpty=!socialMedia.socialMediaEnabled}"></sly>
-
-<sly data-sly-test="${socialMedia.facebookEnabled && socialMedia.facebookAppId}">
-  <amp-social-share type="facebook" data-param-app_id="${socialMedia.facebookAppId}"></amp-social-share>
-</sly>
-
-<sly data-sly-test="${socialMedia.pinterestEnabled}">
-  <amp-social-share type="pinterest" data-param-media="${socialMedia.metadata.og:image}"></amp-social-share>
-</sly>
+<amp-social-share data-sly-test="${socialMedia.facebookEnabled && socialMedia.facebookAppId}"
+                  type="facebook"
+                  data-param-app_id="${socialMedia.facebookAppId}"></amp-social-share>
+<amp-social-share data-sly-test="${socialMedia.pinterestEnabled}"
+                  type="pinterest"
+                  data-param-media="${socialMedia.metadata.og:image}"></amp-social-share>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
@@ -13,41 +13,21 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-  
-<div data-sly-use.tabs="com.adobe.cq.wcm.core.components.models.Tabs"
-     data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
-     class="cmp-tabs"
-     data-cmp-is="tabs">
-
-    <amp-selector data-sly-test="${tabs.items && tabs.items.size > 0}"
-        role="tablist"
-        data-sly-list.tab="${tabs.items}"
-        class="cmp-tabs__tablist tabs-with-flex"
-        aria-label="${tabs.accessibilityLabel}"
-        aria-multiselectable="false">
-        <sly data-sly-test.isActive="${tab.name == tabs.activeItem}"/>
-
-        <div role="tab"
-             option
-             id="tab-item${tabs.tabsId}-${tabList.index}"
-             aria-controls="tab-panel${tabs.tabsId}-${tabList.index}"
-             class="cmp-tabs__tab"
-             data-sly-attribute.selected=${isActive}
-             tabindex="${isActive ? '0' : '-1'}"
-             data-cmp-hook-tabs="tab">
-             ${tab.title}
-        </div>
-
-        <div id="tab-panel${tabs.tabsId}-${tabList.index}"
-             aria-labelledby="tab-item${tabs.tabsId}-${tabList.index}"
-             data-sly-resource="${tab.name @ decorationTagName='div'}"
-             role="tabpanel"
-             tabindex="0"
-             class="cmp-tabs__tabpanel${tab.name == tabs.activeItem ? ' cmp-tabs__tabpanel--active' : ''}"
-             data-cmp-hook-tabs="tabpanel"></div>
-
-        <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
-             data-sly-test="${(wcmmode.edit || wcmmode.preview) && tabs.items.size < 1}">
-        </sly>         
-    </amp-selector>
-</div>
+<amp-selector data-sly-use.tabs="com.adobe.cq.wcm.core.components.models.Tabs"
+              data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+              data-sly-test="${tabs.items && tabs.items.size > 0}"
+              data-sly-list.item="${tabs.items}"
+              class="cmp-tabs tabs-with-flex"
+              role="tablist">
+    <div id="tab-item${tabs.tabsId}-${itemList.index}"
+         class="cmp-tabs__tab"
+         option
+         selected="${item.name == tabs.activeItem}"
+         role="tab"
+         aria-controls="tab-panel${tabs.tabsId}-${itemList.index}">${item.title}</div>
+    <div id="tab-panel${tabs.tabsId}-${itemList.index}"
+         aria-labelledby="tab-item${tabs.tabsId}-${itemList.index}"
+         data-sly-resource="${item.name @ decorationTagName='div'}"
+         role="tabpanel"
+         class="cmp-tabs__tabpanel"></div>
+</amp-selector>

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/search/clientlibs/amp/css/search.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/search/clientlibs/amp/css/search.less
@@ -22,10 +22,6 @@
         margin: 0 10px;
     }
 
-    &__auto-complete {
-        width: 100%;
-    }
-
     &__icon {
         display: block;
         position: absolute;

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/amp/css/tabs.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/components/tabs/clientlibs/amp/css/tabs.less
@@ -75,22 +75,11 @@ amp-selector [option][selected] {
     outline: none;
 }
 
-.cmp-tabs {
-    &__tablist {
-        display: flex;
-        flex-wrap: wrap;
-        border-bottom: 0.0625rem solid;
-        padding-left: 0;
-        list-style: none;
-        border-color: #e1e1e1;
-    }
-
-    &__tab {
-        &[aria-selected="true"] {
-            border: 0;
-            outline: none;
-            border-bottom: 2px solid @gray;
-            color: @gray;
-        }
+.cmp-tabs__tab {
+    &[selected] {
+        border: 0;
+        outline: none;
+        border-bottom: 2px solid @gray;
+        color: @gray;
     }
 }


### PR DESCRIPTION
General review of the component AMP markup provided in the `amp.html` files.

**Note:** This PR currently addresses AMP markup improvements for the Tabs, Accordion, Carousel, Search and Social Sharing components. It will be updated for the other components that have an AMP-specific markup (Image and Form components).

## General
- simplification of markup and attributes where relevant.
- removes unnecessary component wrapper divs and uses `amp-*` elements as the wrapper where possible.
- removes unused component attributes that are relevant to the base html but not in the AMP rendering. Examples include,  `data-cmp-is` and `data-cmp-hook-<component>` etc.
- removes default CSS state classes, that aren't correctly toggled by AMP.
- removes component placeholders for container components, given that the standard editing functionality isn't currently supported/functional.
- HTL
  - removes unnecessary sly wrappers
  - removes unnecessary data-sly-attribute usages
  - uses HTL comments rather than HTML ones
- general formatting fixes
- removes usage of aria attributes for styling

## Search
- replaces `.cmp-search__auto-complete` with `.cmp-search__field`.

## Tabs
- replaces `.cmp-tabs__tablist` with `.cmp-tabs`.
