### PR TITLE
[AMP] Generic component IDs

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -340,6 +340,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractComponentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/AbstractComponentImpl.java
@@ -15,11 +15,21 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.wcm.core.components.internal.models.v1;
 
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.Template;
+import com.day.cq.wcm.api.components.ComponentContext;
 
 import com.adobe.cq.wcm.core.components.models.Component;
 
@@ -28,8 +38,16 @@ import com.adobe.cq.wcm.core.components.models.Component;
  */
 public abstract class AbstractComponentImpl implements Component {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractComponentImpl.class);
+
     @SlingObject
     protected Resource resource;
+
+    @ScriptVariable
+    protected ComponentContext componentContext;
+
+    @ScriptVariable
+    private Page currentPage;
 
     private String id;
 
@@ -41,6 +59,11 @@ public abstract class AbstractComponentImpl implements Component {
                 ValueMap properties = resource.getValueMap();
                 id = properties.get(Component.PN_ID, String.class);
             }
+            if (StringUtils.isEmpty(id)) {
+                id = generateId();
+            } else {
+                id = StringUtils.replace(StringUtils.normalizeSpace(StringUtils.trim(id)), " ", "-");
+            }
         }
         return id;
     }
@@ -49,5 +72,55 @@ public abstract class AbstractComponentImpl implements Component {
     @Override
     public String getExportedType() {
         return resource.getResourceType();
+    }
+
+    /**
+     * Returns an auto generated component ID.
+     *
+     * The ID is the first 10 digits of an SHA-1 hexadecimal hash of the component path,
+     * prefixed with the component name. Example: title-810f3af321
+     *
+     * If the component is referenced, the path is taken to be a concatenation of the component path,
+     * with the path of the first parent context resource that exists on the page or in the template.
+     * This ensures the ID is unique if the same component is referenced multiple times on the same page or template.
+     *
+     * Collision:
+     * ---------
+     * P ~= (n^2)/(2m) - where n is the number of items and m is the number of possibilities for each item.
+     * m = 16^c - for a hexadecimal string, where c is the number of characters.
+     *
+     * say n = 1000 components on the page, with the same name.
+     *
+     * P ~= (1000^2)(2*(16^10))
+     * P ~= 0.000000454747351
+     *
+     * @return the auto generated component ID
+     */
+    private String generateId() {
+        String resourceType = resource.getResourceType();
+        String prefix = StringUtils.substringAfterLast(resourceType, "/");
+        String path = resource.getPath();
+        PageManager pageManager = currentPage.getPageManager();
+        Page containingPage = pageManager.getContainingPage(resource);
+        Template template = currentPage.getTemplate();
+        Boolean inCurrentPage = (containingPage != null && StringUtils.equals(containingPage.getPath(), currentPage.getPath()));
+        Boolean inTemplate = (template != null && path.startsWith(template.getPath()));
+        if (!inCurrentPage && !inTemplate) {
+            ComponentContext parentContext = componentContext.getParent();
+            while (parentContext != null) {
+                Resource parentContextResource = parentContext.getResource();
+                if (parentContextResource != null) {
+                    Page parentContextPage = pageManager.getContainingPage(parentContextResource);
+                    inCurrentPage = (parentContextPage != null && StringUtils.equals(parentContextPage.getPath(), currentPage.getPath()));
+                    inTemplate = (template != null && parentContextResource.getPath().startsWith(template.getPath()));
+                    if (inCurrentPage || inTemplate) {
+                        path = parentContextResource.getPath().concat(resource.getPath());
+                        break;
+                    }
+                }
+                parentContext = parentContext.getParent();
+            }
+        }
+        return prefix + "-" + StringUtils.substring(DigestUtils.sha1Hex(path), 0, 10);
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentImpl.java
@@ -1,0 +1,25 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.models.annotations.Model;
+
+import com.adobe.cq.wcm.core.components.models.Component;
+
+@Model(adaptables = SlingHttpServletRequest.class, adapters = Component.class)
+public class ComponentImpl extends AbstractComponentImpl {
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImpl.java
@@ -136,7 +136,8 @@ public class NavigationImpl implements Navigation {
                 } else if (liveCopiesIterator != null) {
                     while (liveCopiesIterator.hasNext()) {
                         LiveRelationship relationship = (LiveRelationship) liveCopiesIterator.next();
-                        if (currentPage.getPath().startsWith(relationship.getTargetPath() + "/")) {
+                        String currentPagePath = currentPage.getPath() + "/";
+                        if (currentPagePath.startsWith(relationship.getTargetPath() + "/")) {
                             Page liveCopyNavigationRoot = pageManager.getPage(relationship.getTargetPath());
                             if (liveCopyNavigationRoot != null) {
                                 navigationRoot = new NavigationRoot(liveCopyNavigationRoot, structureDepth);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
@@ -82,14 +82,4 @@ public class TabsImpl extends PanelContainerImpl implements Tabs {
     public String getAccessibilityLabel() {
         return accessibilityLabel;
     }
-
-    @Override
-    public String getTabsId() {
-        String resourcePath = resource.getPath();
-        String identifier = resourcePath.substring(resourcePath.indexOf(JCR_CONTENT) + JCR_CONTENT.length());
-        if (resourcePath.startsWith("/conf")) {
-            identifier += "-template";
-        }
-        return identifier.replace("/", "-");
-    }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/AdaptiveImageServlet.java
@@ -736,8 +736,8 @@ public class AdaptiveImageServlet extends SlingSafeMethodsServlet {
     private long getRequestLastModifiedSuffix(@Nullable String suffix) {
         long requestLastModified = 0;
         if (StringUtils.isNotEmpty(suffix) && suffix.contains(".")) {
-            // check if the 13 digits UTC milliseconds timestamp is present in the suffix
-            Pattern p = Pattern.compile("\\(|\\)|\\d{13}");
+            // check if the 13 digits UTC milliseconds timestamp, preceded by a forward slash is present in the suffix
+            Pattern p = Pattern.compile("\\(|\\)|\\/\\d{13}");
             Matcher m = p.matcher(suffix);
             if (!m.find()) {
                 return requestLastModified;

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
@@ -44,14 +44,4 @@ public interface Tabs extends Container {
     default String getAccessibilityLabel() {
         throw new UnsupportedOperationException();
     }
-
-    /**
-     * Returns an unique ID for the tab based on resource path.
-     *
-     * @return an UID for tabs
-     * @since com.adobe.cq.wcm.core.components.models 12.13.0
-     */
-    default String getTabsId() {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.14.0")
+@Version("12.12.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ComponentImplTest.java
@@ -1,0 +1,92 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2020 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.adobe.cq.sightly.WCMBindings;
+import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
+import com.adobe.cq.wcm.core.components.models.Component;
+import com.day.cq.wcm.api.components.ComponentContext;
+import com.day.cq.wcm.api.Page;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(AemContextExtension.class)
+public class ComponentImplTest {
+
+    private static final String TEST_BASE = "/experiencefragment";
+    private static final String TEST_PAGE = "/content/mysite/page";
+    private static final String TEST_PAGE_EN = "/content/mysite/en/page";
+    private static final String XF_COMPONENT_1 = TEST_PAGE + "/jcr:content/root/xf-component-1";
+    private static final String XF_COMPONENT_10 = TEST_PAGE_EN + "/jcr:content/root/xf-component-10";
+
+    private final AemContext context = CoreComponentTestContext.newAemContext();
+
+    @BeforeEach
+    void setUp() {
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, "/content");
+    }
+
+    @Test
+    public void testComponentId() {
+        Component component = getComponentUnderTest(XF_COMPONENT_1);
+        Assert.assertEquals("ID mismatch", "experiencefragment-77cae01492", component.getId());
+    }
+
+    @Test
+    public void testReferencedComponentId() {
+        Component component = getReferencedComponentUnderTest(XF_COMPONENT_1, TEST_PAGE_EN, XF_COMPONENT_10);
+        Assert.assertEquals("ID mismatch", "experiencefragment-5fba9a0f26", component.getId());
+    }
+
+    private Component getComponentUnderTest(String resourcePath, Object ... properties) {
+        Resource resource = context.currentResource(resourcePath);
+        if (resource != null && properties != null) {
+            context.contentPolicyMapping(resource.getResourceType(), properties);
+        }
+        MockSlingHttpServletRequest request = context.request();
+        return request.adaptTo(Component.class);
+    }
+
+    private Component getReferencedComponentUnderTest(String resourcePath, String currentPagePath, String referencerPath, Object ... properties) {
+        Resource resource = context.currentResource(resourcePath);
+        if (resource != null && properties != null) {
+            context.contentPolicyMapping(resource.getResourceType(), properties);
+        }
+        Resource referencer = context.resourceResolver().getResource(referencerPath);
+        SlingBindings slingBindings = new SlingBindings();
+        ComponentContext componentContext = mock(ComponentContext.class);
+        ComponentContext parentContext = mock(ComponentContext.class);
+        when(parentContext.getResource()).thenReturn(referencer);
+        when(componentContext.getParent()).thenReturn(parentContext);
+        Page currentPage = context.pageManager().getPage(currentPagePath);
+        slingBindings.put(WCMBindings.COMPONENT_CONTEXT, componentContext);
+        slingBindings.put(WCMBindings.CURRENT_PAGE, currentPage);
+        MockSlingHttpServletRequest request = context.request();
+        request.setAttribute(SlingBindings.class.getName(), slingBindings);
+        return request.adaptTo(Component.class);
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/LayoutContainerImplTest.java
@@ -34,6 +34,7 @@ import com.adobe.cq.wcm.core.components.models.LayoutContainer;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.adobe.cq.wcm.core.components.testing.MockSlingModelFilter;
 import com.adobe.cq.wcm.core.components.testing.MockStyle;
+import com.day.cq.wcm.api.components.ComponentContext;
 import com.day.cq.wcm.api.designer.Style;
 import io.wcm.testing.mock.aem.junit.AemContext;
 
@@ -76,7 +77,7 @@ public class LayoutContainerImplTest {
         assertEquals("Layout type mismatch",
                 LayoutContainer.LayoutType.RESPONSIVE_GRID,
                 container.getLayout());
-        assertEquals("Id mismatch",
+        assertEquals("ID mismatch",
                 "test",
                 container.getId());
         Object[][] expectedItems = {
@@ -89,24 +90,24 @@ public class LayoutContainerImplTest {
                 container.getExportedType());
         Utils.testJSONExport(container, Utils.getTestExporterJSONPath(TEST_BASE, "container1"));
     }
-    
+
     @Test
     public void testContainerNoProperties() {
         LayoutContainer container = getContainerUnderTest(CONTAINER_2, null);
-        assertNull("Id", container.getId());
+        assertEquals("ID mismatch", "container-1fe48feca7", container.getId());
         assertNull("Style", container.getBackgroundStyle());
         assertEquals("Layout type mismatch",
                 LayoutContainer.LayoutType.SIMPLE,
                 container.getLayout());
     }
-    
+
     @Test
     public void testContainerWithPropertiesAndNoPolicy() {
         LayoutContainer container = getContainerUnderTest(CONTAINER_3, null);
-        assertNull("Id", container.getId());
+        assertEquals("ID mismatch", "container-0880528a35", container.getId());
         assertNull("Style", container.getBackgroundStyle());
     }
-    
+
     private void verifyContainerItems(Object[][] expectedItems, List<ListItem> items) {
         assertEquals("Item number mismatch", expectedItems.length, items.size());
         int index = 0;
@@ -123,10 +124,12 @@ public class LayoutContainerImplTest {
         }
 
         SlingBindings bindings = new SlingBindings();
+        ComponentContext componentContext = mock(ComponentContext.class);
         bindings.put(SlingBindings.RESOURCE, resource);
         bindings.put(SlingBindings.REQUEST, AEM_CONTEXT.request());
         bindings.put(WCMBindings.PROPERTIES, resource.getValueMap());
         bindings.put(WCMBindings.CURRENT_PAGE, AEM_CONTEXT.pageManager().getPage(TEST_PAGE));
+        bindings.put(WCMBindings.COMPONENT_CONTEXT, componentContext);
         bindings.put(WCMBindings.PAGE_MANAGER, AEM_CONTEXT.pageManager());
         if (style == null) {
             Resource mockResource = mock(Resource.class);

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/NavigationImplTest.java
@@ -78,6 +78,7 @@ class NavigationImplTest {
     private static final String NAV_COMPONENT_12 = TEST_ROOT + "/jcr:content/root/navigation-component-12";
     private static final String NAV_COMPONENT_13 = TEST_ROOT + "/jcr:content/root/navigation-component-13";
     private static final String NAV_COMPONENT_14 = TEST_ROOT + "/jcr:content/root/navigation-component-14";
+    private static final String NAV_COMPONENT_15 = "/content/navigation-livecopy/jcr:content/root/navigation-component-15";
 
     @BeforeEach
     void setUp() throws WCMException {
@@ -272,6 +273,21 @@ class NavigationImplTest {
                 {"/content/navigation-livecopy/1/1-3", 2, false, "/content/navigation-livecopy/1/1-3.html"},
                 {"/content/navigation-livecopy/2", 1, true, "/content/navigation-livecopy/2.html"},
                 {"/content/navigation-livecopy/3", 1, false, "/content/navigation-livecopy/3.html"},
+
+        };
+        verifyNavigationItems(expectedPages, getNavigationItems(navigation));
+    }
+
+    @Test
+    void testNavigationWithLiveCopyTreeCurrentPageAtRoot() {
+        Navigation navigation = getNavigationUnderTest(NAV_COMPONENT_15);
+        Object[][] expectedPages = {
+            {"/content/navigation-livecopy", 0, true, "/content/navigation-livecopy.html"},
+            {"/content/navigation-livecopy/1", 1, false, "/content/navigation-livecopy/1.html"},
+            {"/content/navigation-livecopy/1/1-1", 2, false, "/content/navigation-livecopy/1/1-1.html"},
+            {"/content/navigation-livecopy/1/1-3", 2, false, "/content/navigation-livecopy/1/1-3.html"},
+            {"/content/navigation-livecopy/2", 1, false, "/content/navigation-livecopy/2.html"},
+            {"/content/navigation-livecopy/3", 1, false, "/content/navigation-livecopy/3.html"},
 
         };
         verifyNavigationItems(expectedPages, getNavigationItems(navigation));

--- a/bundles/core/src/test/resources/accordion/exporter-accordion1.json
+++ b/bundles/core/src/test/resources/accordion/exporter-accordion1.json
@@ -1,4 +1,5 @@
 {
+    "id": "accordion-123dfbf31c",
     "singleExpansion": false,
     "expandedItems": [
         "item_2"

--- a/bundles/core/src/test/resources/accordion/exporter-accordion2.json
+++ b/bundles/core/src/test/resources/accordion/exporter-accordion2.json
@@ -1,4 +1,5 @@
 {
+    "id": "accordion-4e87b93aff",
     "singleExpansion": false,
     "expandedItems": [
         "item_2"
@@ -7,10 +8,8 @@
         "item_1",
         "item_2"
     ],
-    ":type": "core/wcm/components/accordion/v1/accordion",
     ":items": {
         "item_1": {
-            ":type": "core/wcm/components/responsivegrid",
             ":items": {
                 "item_1_1": {
                     "title": "Teaser 1",
@@ -22,6 +21,7 @@
                     ":type": "core/wcm/components/teaser/v1/teaser"
                 },
                 "item_1_2": {
+                    "id": "accordion-d95ca85950",
                     "singleExpansion": false,
                     "expandedItems": [
                         "item_1_2_2"
@@ -30,10 +30,8 @@
                         "item_1_2_1",
                         "item_1_2_2"
                     ],
-                    ":type": "core/wcm/components/accordion/v1/accordion",
                     ":items": {
                         "item_1_2_1": {
-                            ":type": "core/wcm/components/responsivegrid",
                             ":items": {
                                 "item_1_2_1_1": {
                                     "title": "Teaser 1",
@@ -58,10 +56,10 @@
                                 "item_1_2_1_1",
                                 "item_1_2_1_2"
                             ],
+                            ":type": "core/wcm/components/responsivegrid",
                             "cq:panelTitle": "Accordion Item 1.1"
                         },
                         "item_1_2_2": {
-                            ":type": "core/wcm/components/responsivegrid",
                             ":items": {
                                 "item_1_2_2_1": {
                                     "title": "Teaser 1",
@@ -73,6 +71,7 @@
                                     ":type": "core/wcm/components/teaser/v1/teaser"
                                 },
                                 "item_1_2_2_2": {
+                                    "id": "carousel-87fe1dbabd",
                                     "autoplay": false,
                                     "delay": 5000,
                                     "autopauseDisabled": false,
@@ -81,7 +80,6 @@
                                         "item_1_2_2_2_2",
                                         "item_1_2_2_2_3"
                                     ],
-                                    ":type": "core/wcm/components/carousel/v1/carousel",
                                     ":items": {
                                         "item_1_2_2_2_1": {
                                             "title": "Teaser 1",
@@ -113,26 +111,29 @@
                                             ":type": "core/wcm/components/teaser/v1/teaser",
                                             "cq:panelTitle": "Teaser 3"
                                         }
-                                    }
+                                    },
+                                    ":type": "core/wcm/components/carousel/v1/carousel"
                                 }
                             },
                             ":itemsOrder": [
                                 "item_1_2_2_1",
                                 "item_1_2_2_2"
                             ],
+                            ":type": "core/wcm/components/responsivegrid",
                             "cq:panelTitle": "Accordion Item 1.2"
                         }
-                    }
+                    },
+                    ":type": "core/wcm/components/accordion/v1/accordion"
                 }
             },
             ":itemsOrder": [
                 "item_1_1",
                 "item_1_2"
             ],
+            ":type": "core/wcm/components/responsivegrid",
             "cq:panelTitle": "Accordion Item 1"
         },
         "item_2": {
-            ":type": "core/wcm/components/responsivegrid",
             ":items": {
                 "item_2_1": {
                     "title": "Teaser 1",
@@ -157,7 +158,9 @@
                 "item_2_1",
                 "item_2_2"
             ],
+            ":type": "core/wcm/components/responsivegrid",
             "cq:panelTitle": "Accordion Item 2"
         }
-    }
+    },
+    ":type": "core/wcm/components/accordion/v1/accordion"
 }

--- a/bundles/core/src/test/resources/accordion/exporter-accordion3.json
+++ b/bundles/core/src/test/resources/accordion/exporter-accordion3.json
@@ -1,4 +1,5 @@
 {
+    "id": "accordion-04593f189f",
     "singleExpansion": true,
     "expandedItems": [
         "item_2"

--- a/bundles/core/src/test/resources/carousel/exporter-carousel1.json
+++ b/bundles/core/src/test/resources/carousel/exporter-carousel1.json
@@ -1,4 +1,5 @@
 {
+    "id": "carousel-e4eef01f3a",
     "autoplay": true,
     "delay": 7000,
     "autopauseDisabled": true,
@@ -7,7 +8,6 @@
         "item_2",
         "item_3"
     ],
-    ":type": "core/wcm/components/carousel/v1/carousel",
     ":items": {
         "item_1": {
             "title": "Teaser 1",
@@ -22,7 +22,7 @@
         "item_2": {
             "title": "Teaser 2",
             "description": "Teaser 2 description",
-            "actionsEnabled" : false,
+            "actionsEnabled": false,
             "imageLinkHidden": false,
             "titleLinkHidden": false,
             "actions": [],
@@ -32,12 +32,13 @@
         "item_3": {
             "title": "Teaser 3",
             "description": "Teaser 3 description",
-            "actionsEnabled" : false,
+            "actionsEnabled": false,
             "imageLinkHidden": false,
             "titleLinkHidden": false,
             "actions": [],
             ":type": "core/wcm/components/teaser/v1/teaser",
             "cq:panelTitle": "Carousel Panel 3"
         }
-    }
+    },
+    ":type": "core/wcm/components/carousel/v1/carousel"
 }

--- a/bundles/core/src/test/resources/navigation/test-content.json
+++ b/bundles/core/src/test/resources/navigation/test-content.json
@@ -313,7 +313,16 @@
     "navigation-livecopy"         : {
         "jcr:primaryType": "cq:Page",
         "jcr:content"    : {
-            "jcr:primaryType": "cq:PageContent"
+            "jcr:primaryType": "cq:PageContent",
+            "root"           : {
+                "jcr:primaryType"        : "nt:unstructured",
+                "navigation-component-15": {
+                    "jcr:primaryType"   : "nt:unstructured",
+                    "sling:resourceType": "core/wcm/components/navigation/v1/navigation",
+                    "navigationRoot"    : "/content/navigation-blueprint",
+                    "skipNavigationRoot": false
+                }
+            }
         },
         "1"              : {
             "jcr:primaryType": "cq:Page",

--- a/bundles/core/src/test/resources/tabs/exporter-tabs1.json
+++ b/bundles/core/src/test/resources/tabs/exporter-tabs1.json
@@ -1,7 +1,6 @@
 {
     "id": "tabs-5d4d947d94",
     "activeItem": "item_2",
-    "tabsId": "-root-responsivegrid-tabs-1",
     ":itemsOrder": [
         "item_1",
         "item_2"

--- a/bundles/core/src/test/resources/tabs/exporter-tabs1.json
+++ b/bundles/core/src/test/resources/tabs/exporter-tabs1.json
@@ -1,17 +1,12 @@
 {
+    "id": "tabs-5d4d947d94",
     "activeItem": "item_2",
     ":itemsOrder": [
         "item_1",
         "item_2"
     ],
-    ":type": "core/wcm/components/tabs/v1/tabs",
     ":items": {
         "item_1": {
-            ":itemsOrder": [
-                "item_1_1",
-                "item_1_2"
-            ],
-            ":type": "core/wcm/components/responsivegrid",
             ":items": {
                 "item_1_1": {
                     "title": "Teaser 1",
@@ -32,14 +27,14 @@
                     ":type": "core/wcm/components/teaser/v1/teaser"
                 }
             },
+            ":itemsOrder": [
+                "item_1_1",
+                "item_1_2"
+            ],
+            ":type": "core/wcm/components/responsivegrid",
             "cq:panelTitle": "Tab 1"
         },
         "item_2": {
-            ":itemsOrder": [
-                "item_2_1",
-                "item_2_2"
-            ],
-            ":type": "core/wcm/components/responsivegrid",
             ":items": {
                 "item_2_1": {
                     "title": "Teaser 1",
@@ -60,7 +55,13 @@
                     ":type": "core/wcm/components/teaser/v1/teaser"
                 }
             },
+            ":itemsOrder": [
+                "item_2_1",
+                "item_2_2"
+            ],
+            ":type": "core/wcm/components/responsivegrid",
             "cq:panelTitle": "Tab Panel 2"
         }
-    }
+    },
+    ":type": "core/wcm/components/tabs/v1/tabs"
 }

--- a/bundles/core/src/test/resources/tabs/exporter-tabs2.json
+++ b/bundles/core/src/test/resources/tabs/exporter-tabs2.json
@@ -1,7 +1,6 @@
 {
     "id": "tabs-7e84106a6a",
     "activeItem": "item_2",
-    "tabsId": "-root-responsivegrid-tabs-2",
     ":itemsOrder": [
         "item_1",
         "item_2"
@@ -21,7 +20,6 @@
                 "item_1_2": {
                     "id": "tabs-e14a27b1c3",
                     "activeItem": "item_1_2_2",
-                    "tabsId": "-root-responsivegrid-tabs-2-item_1-item_1_2",
                     ":itemsOrder": [
                         "item_1_2_1",
                         "item_1_2_2"

--- a/bundles/core/src/test/resources/tabs/exporter-tabs2.json
+++ b/bundles/core/src/test/resources/tabs/exporter-tabs2.json
@@ -1,17 +1,12 @@
 {
+    "id": "tabs-7e84106a6a",
     "activeItem": "item_2",
     ":itemsOrder": [
         "item_1",
         "item_2"
     ],
-    ":type": "core/wcm/components/tabs/v1/tabs",
     ":items": {
         "item_1": {
-            ":itemsOrder": [
-                "item_1_1",
-                "item_1_2"
-            ],
-            ":type": "core/wcm/components/responsivegrid",
             ":items": {
                 "item_1_1": {
                     "title": "Teaser 1",
@@ -23,19 +18,14 @@
                     ":type": "core/wcm/components/teaser/v1/teaser"
                 },
                 "item_1_2": {
+                    "id": "tabs-e14a27b1c3",
                     "activeItem": "item_1_2_2",
                     ":itemsOrder": [
                         "item_1_2_1",
                         "item_1_2_2"
                     ],
-                    ":type": "core/wcm/components/tabs/v1/tabs",
                     ":items": {
                         "item_1_2_1": {
-                            ":itemsOrder": [
-                                "item_1_2_1_1",
-                                "item_1_2_1_2"
-                            ],
-                            ":type": "core/wcm/components/responsivegrid",
                             ":items": {
                                 "item_1_2_1_1": {
                                     "title": "Teaser 1",
@@ -56,14 +46,14 @@
                                     ":type": "core/wcm/components/teaser/v1/teaser"
                                 }
                             },
+                            ":itemsOrder": [
+                                "item_1_2_1_1",
+                                "item_1_2_1_2"
+                            ],
+                            ":type": "core/wcm/components/responsivegrid",
                             "cq:panelTitle": "Tab 1.1"
                         },
                         "item_1_2_2": {
-                            ":itemsOrder": [
-                                "item_1_2_2_1",
-                                "item_1_2_2_2"
-                            ],
-                            ":type": "core/wcm/components/responsivegrid",
                             ":items": {
                                 "item_1_2_2_1": {
                                     "title": "Teaser 1",
@@ -75,15 +65,15 @@
                                     ":type": "core/wcm/components/teaser/v1/teaser"
                                 },
                                 "item_1_2_2_2": {
-                                    "autopauseDisabled": false,
+                                    "id": "carousel-b2fb964605",
                                     "autoplay": false,
                                     "delay": 5000,
+                                    "autopauseDisabled": false,
                                     ":itemsOrder": [
                                         "item_1_2_2_2_1",
                                         "item_1_2_2_2_2",
                                         "item_1_2_2_2_3"
                                     ],
-                                    ":type": "core/wcm/components/carousel/v1/carousel",
                                     ":items": {
                                         "item_1_2_2_2_1": {
                                             "title": "Teaser 1",
@@ -115,22 +105,29 @@
                                             ":type": "core/wcm/components/teaser/v1/teaser",
                                             "cq:panelTitle": "Teaser 3"
                                         }
-                                    }
+                                    },
+                                    ":type": "core/wcm/components/carousel/v1/carousel"
                                 }
                             },
+                            ":itemsOrder": [
+                                "item_1_2_2_1",
+                                "item_1_2_2_2"
+                            ],
+                            ":type": "core/wcm/components/responsivegrid",
                             "cq:panelTitle": "Tab 1.2"
                         }
-                    }
+                    },
+                    ":type": "core/wcm/components/tabs/v1/tabs"
                 }
             },
+            ":itemsOrder": [
+                "item_1_1",
+                "item_1_2"
+            ],
+            ":type": "core/wcm/components/responsivegrid",
             "cq:panelTitle": "Tab 1"
         },
         "item_2": {
-            ":itemsOrder": [
-                "item_2_1",
-                "item_2_2"
-            ],
-            ":type": "core/wcm/components/responsivegrid",
             ":items": {
                 "item_2_1": {
                     "title": "Teaser 1",
@@ -151,7 +148,13 @@
                     ":type": "core/wcm/components/teaser/v1/teaser"
                 }
             },
+            ":itemsOrder": [
+                "item_2_1",
+                "item_2_2"
+            ],
+            ":type": "core/wcm/components/responsivegrid",
             "cq:panelTitle": "Tab 2"
         }
-    }
+    },
+    ":type": "core/wcm/components/tabs/v1/tabs"
 }

--- a/bundles/core/src/test/resources/tabs/exporter-tabs3.json
+++ b/bundles/core/src/test/resources/tabs/exporter-tabs3.json
@@ -1,6 +1,6 @@
 {
     "activeItem": "item_1",
-    "tabsId": "-root-responsivegrid-tabs-3",
+    "id":"tabs-bd3cb85fb2",
     ":itemsOrder": [
         "item_1",
         "item_2"

--- a/content/pom.xml
+++ b/content/pom.xml
@@ -74,6 +74,12 @@
                         <configuration>
                             <generateJavaClasses>true</generateJavaClasses>
                             <generatedJavaClassesPrefix>org.apache.sling.scripting.sightly</generatedJavaClassesPrefix>
+                            <allowedExpressionOptions>
+                                <allowedExpressionOption>cssClassName</allowedExpressionOption>
+                                <allowedExpressionOption>decoration</allowedExpressionOption>
+                                <allowedExpressionOption>decorationTagName</allowedExpressionOption>
+                                <allowedExpressionOption>wcmmode</allowedExpressionOption>
+                            </allowedExpressionOptions>
                         </configuration>
                     </execution>
                 </executions>
@@ -206,13 +212,13 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.scripting.sightly.compiler</artifactId>
-            <version>1.0.22-1.4.0</version>
+            <version>1.2.4-1.4.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.scripting.sightly.compiler.java</artifactId>
-            <version>1.0.24-1.4.0</version>
+            <artifactId>org.apache.sling.scripting.sightly.runtime</artifactId>
+            <version>1.2.0-1.4.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/README.md
@@ -42,8 +42,9 @@ It is also possible to define the allowed components for the Accordion.
 The following properties are written to JCR for this Accordion component and are expected to be available as `Resource` properties:
 
 1. `./singleExpansion` - `true` if one panel should be forced to be expanded at a time, `false` otherwise.
-1. `./expandedItems` - defines the names of the items that are expanded by default.
-2. `./headingElement` - defines the heading element to use for the accordion headers (`h2` - `h6`).
+2. `./expandedItems` - defines the names of the items that are expanded by default.
+3. `./headingElement` - defines the heading element to use for the accordion headers (`h2` - `h6`).
+4. `./id` - defines the component HTML ID attribute.
 
 The edit dialog also allows editing of Accordion items (adding, removing, naming, re-ordering).
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/_cq_dialog/.content.xml
@@ -151,6 +151,12 @@
                                                     jcr:primaryType="nt:unstructured"
                                                     cmp-accordion-v1-dialog-edit-hook="headingElement"/>
                                             </headingElement>
+                                            <id
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="HTML ID attribute to apply to the component."
+                                                fieldLabel="ID"
+                                                name="./id"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/accordion.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/accordion.html
@@ -14,6 +14,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.accordion="com.adobe.cq.wcm.core.components.models.Accordion"
+     id="${accordion.id}"
      class="cmp-accordion"
      data-cmp-is="accordion"
      data-cmp-single-expansion="${accordion.singleExpansion}">
@@ -24,7 +25,9 @@
          data-cmp-expanded="${item.name in accordion.expandedItems}">
         <h3 data-sly-element="${accordion.headingElement @ context='elementName'}"
             class="cmp-accordion__header">
-            <button class="cmp-accordion__button${item.name in accordion.expandedItems ? ' cmp-accordion__button--expanded' : ''}"
+            <button id="${accordion.id}-button-${itemList.index}"
+                    class="cmp-accordion__button${item.name in accordion.expandedItems ? ' cmp-accordion__button--expanded' : ''}"
+                    aria-controls="${accordion.id}-panel-${itemList.index}"
                     data-cmp-hook-accordion="button">
                 <span class="cmp-accordion__title">${item.title}</span>
                 <span class="cmp-accordion__icon"></span>
@@ -32,8 +35,10 @@
         </h3>
         <div data-sly-resource="${item.name @ decorationTagName='div'}"
              data-cmp-hook-accordion="panel"
+             id="${accordion.id}-panel-${itemList.index}"
              class="cmp-accordion__panel${item.name in accordion.expandedItems ? ' cmp-accordion__panel--expanded' : ' cmp-accordion__panel--hidden'}"
-             role="region"></div>
+             role="region"
+             aria-labelledby="${accordion.id}-button-${itemList.index}"></div>
     </div>
     <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
          data-sly-test="${(wcmmode.edit || wcmmode.preview) && accordion.items.size < 1}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/amp.html
@@ -15,18 +15,23 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <amp-accordion data-sly-use.accordion="com.adobe.cq.wcm.core.components.models.Accordion"
                data-sly-test="${accordion.items && accordion.items.size > 0}"
+               id="${accordion.id}"
                class="cmp-accordion"
                expand-single-section="${accordion.singleExpansion}">
     <section data-sly-repeat.item="${accordion.items}"
              class="cmp-accordion__item"
              expanded="${item.name in accordion.expandedItems}">
         <h3 data-sly-element="${accordion.headingElement @ context='elementName'}"
-            class="cmp-accordion__header">
+            id="${accordion.id}-button-${itemList.index}"
+            class="cmp-accordion__button"
+            aria-controls="${accordion.id}-panel-${itemList.index}">
             <span class="cmp-accordion__title">${item.title}</span>
             <span class="cmp-accordion__icon"></span>
         </h3>
         <div data-sly-resource="${item.name @ decorationTagName='div'}"
+             id="${accordion.id}-panel-${itemList.index}"
              class="cmp-accordion__panel"
-             role="region"></div>
+             role="region"
+             aria-labelledby="${accordion.id}-button-${itemList.index}"></div>
     </section>
 </amp-accordion>

--- a/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v2/breadcrumb/breadcrumb.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/breadcrumb/v2/breadcrumb/breadcrumb.html
@@ -13,10 +13,12 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<nav class="cmp-breadcrumb"
-     aria-label="${'Breadcrumb' @ i18n}"
-     data-sly-use.breadcrumb="com.adobe.cq.wcm.core.components.models.Breadcrumb"
+<nav data-sly-use.breadcrumb="com.adobe.cq.wcm.core.components.models.Breadcrumb"
+     data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-use.template="core/wcm/components/commons/v1/templates.html"
+     id="${component.id}"
+     class="cmp-breadcrumb"
+     aria-label="${'Breadcrumb' @ i18n}"
      data-sly-test="${breadcrumb.items.size > 0}">
     <ol class="cmp-breadcrumb__list"
         itemscope itemtype="http://schema.org/BreadcrumbList"

--- a/content/src/content/jcr_root/apps/core/wcm/components/button/v1/button/button.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/button/v1/button/button.html
@@ -14,8 +14,10 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <button data-sly-use.button="com.adobe.cq.wcm.core.components.models.Button"
+        data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
         data-sly-use.iconTemplate="icon.html"
         data-sly-element="${button.link ? 'a' : 'button'}"
+        id="${component.id}"
         class="cmp-button"
         href="${button.link}"
         aria-label="${button.accessibilityLabel}">

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
@@ -47,7 +47,8 @@ The following properties are written to JCR for this Carousel component and are 
 1. `./autoplay` - defines whether or not the carousel should automatically transition between slides.
 2. `./delay` - defines the delay (in milliseconds) when automatically transitioning between slides.
 3. `./autopauseDisabled` - defines whether or not automatic pause when hovering the carousel is disabled.
-4. `./accessibilityLabel` - defines an accessibility label for the carousel.
+4. `./id` - defines the component HTML ID attribute.
+5. `./accessibilityLabel` - defines an accessibility label for the carousel.
 
 The edit dialog also allows editing of Carousel items (adding, removing, naming, re-ordering).
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -128,6 +128,12 @@
                                                     jcr:primaryType="nt:unstructured"
                                                     cmp-carousel-v1-dialog-hook="autoplayGroup"/>
                                             </autoplayGroup>
+                                            <id
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="HTML ID attribute to apply to the component."
+                                                fieldLabel="ID"
+                                                name="./id"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/amp.html
@@ -16,6 +16,7 @@
 <amp-carousel data-sly-use.carousel="com.adobe.cq.wcm.core.components.models.Carousel"
               data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
               data-sly-test="${carousel.items && carousel.items.size > 0}"
+              id="${carousel.id}"
               class="cmp-carousel"
               role="group"
               aria-label="${carousel.accessibilityLabel}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/carousel.html
@@ -15,6 +15,7 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.carousel="com.adobe.cq.wcm.core.components.models.Carousel"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+     id="${carousel.id}"
      class="cmp-carousel"
      role="group"
      aria-label="${carousel.accessibilityLabel}"
@@ -27,6 +28,7 @@
          class="cmp-carousel__content">
         <div data-sly-repeat.item="${carousel.items}"
              data-sly-resource="${item.name @ decorationTagName='div'}"
+             id="${carousel.id}-item-${itemList.index}"
              class="cmp-carousel__item${itemList.first ? ' cmp-carousel__item--active' : ''}"
              role="tabpanel"
              aria-label="${'Slide {0} of {1}' @ format=[itemList.count, carousel.items.size], i18n}"
@@ -70,6 +72,7 @@
             <li data-sly-repeat.item="${carousel.items}"
                 class="cmp-carousel__indicator${itemList.first ? ' cmp-carousel__indicator--active' : ''}"
                 role="tab"
+                aria-controls="${carousel.id}-item-${itemList.index}"
                 aria-label="${'Slide {0}' @ format=[itemList.count], i18n}"
                 data-cmp-hook-carousel="indicator">${item.title}</li>
         </ol>

--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelselect/js/panelselect.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelselect/js/panelselect.js
@@ -418,7 +418,7 @@
     });
 
     channel.on("cq-layer-activated", function(event) {
-        if (event.layer === "Edit") {
+        if (event.layer === "Edit" || event.layer === "structure" || event.layer === "initial") {
             ns.EditorFrame.editableToolbar.registerAction("PANEL_SELECT", panelSelect);
         }
     });

--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/README.md
@@ -48,9 +48,9 @@ The following properties are written to JCR for this Container component and are
 1. `./layout` - defines the layout type, either `simple` (default) or `responsiveGrid`
 
 #### Common Properties
-1. `./id` - defines the component HTML ID attribute.
-2. `./backgroundImageReference` - defines the container background image.
-3. `./backgroundColor` - defines the container background color.
+1. `./backgroundImageReference` - defines the container background image.
+2. `./backgroundColor` - defines the container background color.
+3. `./id` - defines the component HTML ID attribute.
 
 ## BEM Description
 ```

--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/_cq_dialog/.content.xml
@@ -63,12 +63,6 @@
                                                         value="responsiveGrid"/>
                                                 </items>
                                             </layout>
-                                            <id
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                fieldDescription="HTML ID attribute to apply to the component."
-                                                fieldLabel="ID"
-                                                name="./id"/>
                                             <backgroundColor
                                                 granite:hide="${!cqDesign.backgroundColorEnabled || cqDesign.backgroundColorSwatchesOnly}"
                                                 jcr:primaryType="nt:unstructured"
@@ -115,6 +109,12 @@
                                                 title="Upload Image Asset"
                                                 uploadUrl="${suffix.path}"
                                                 useHTML5="{Boolean}true"/>
+                                            <id
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="HTML ID attribute to apply to the component."
+                                                fieldLabel="ID"
+                                                name="./id"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/README.md
@@ -36,6 +36,7 @@ The following JCR properties are used:
 4. `./paragraphScope` - defines if all or a range of paragraphs are to be rendered (only used in paragraph mode)
 5. `./paragraphRange` - defines the range(s) of paragraphs to be rendered (only used in paragraph mode and if paragraphs are restricted to ranges)
 6. `./paragraphHeadings` - defines if headings should count as paragraphs (only used in paragraph mode and if paragraphs are restricted to ranges)
+7. `./id` - defines the component HTML ID attribute.
 
 ## BEM description
 ```

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/_cq_dialog/.content.xml
@@ -134,6 +134,12 @@
                                             jcr:primaryType="nt:unstructured"
                                             field-path="${requestPathInfo.resourcePath}"/>
                                     </variationName>
+                                    <id
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                        fieldDescription="HTML ID attribute to apply to the component."
+                                        fieldLabel="ID"
+                                        name="./id"/>
                                 </items>
                             </column>
                         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/templates.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment/templates.html
@@ -15,7 +15,9 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 
 <template data-sly-template.contentFragment="${@ fragment='The content fragment', fragmentPath='', wcmmode='WCM mode'}">
-    <article class="cmp-contentfragment cmp-contentfragment--${fragment.name}"
+    <article data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
+             id="${component.id}"
+             class="cmp-contentfragment cmp-contentfragment--${fragment.name}"
              data-cmp-contentfragment-model="${fragment.type}"
              data-sly-attribute.data-cmp-contentfragment-path="${fragmentPath}"
              data-json="${!wcmmode.disabled && fragment.editorJSON}">

--- a/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/contentfragmentlist.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/contentfragmentlist/v1/contentfragmentlist/contentfragmentlist.html
@@ -14,9 +14,10 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <sly data-sly-use.list="com.adobe.cq.wcm.core.components.models.contentfragment.ContentFragmentList"
+     data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-test="${list.listItems.size>0}" data-sly-use.fragmentTemplate="core/wcm/components/contentfragment/v1/contentfragment/templates.html">
-         
     <section data-sly-list.fragment="${list.listItems}"
+             id="${component.id}"
              class="cmp-contentfragmentlist">
         <sly data-sly-call="${fragmentTemplate.contentFragment @ fragment=fragment, wcmmode=wcmmode}"></sly>
     </section>

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/README.md
@@ -40,6 +40,7 @@ The following configuration properties are used:
 4. `./displaySize` - defines whether the file size should be displayed.
 5. `./displayFormat` - defines whether the file format should be displayed.
 6. `./displayFilename` - defines whether the filename should be displayed.
+7. `./id` - defines the component HTML ID attribute.
 
 ### Edit Dialog Properties
 The following JCR properties are used:

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/_cq_dialog/.content.xml
@@ -251,6 +251,12 @@
                                                 text="Display inline"
                                                 uncheckedValue="{Boolean}false"
                                                 value="{Boolean}true"/>
+                                            <id
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="HTML ID attribute to apply to the component."
+                                                fieldLabel="ID"
+                                                name="./id"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/download/v1/download/download.html
@@ -14,8 +14,10 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.download="com.adobe.cq.wcm.core.components.models.Download"
+     data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
      data-sly-test.hasContent="${download.filename}"
+     id="${component.id}"
      class="cmp-download${!wcmmode.disabled ? ' cq-dd-file' : ''}">
     <h3 class="cmp-download__title" data-sly-test.title="${download.title}" data-sly-element="${download.titleType}">
         <a data-sly-unwrap="${!download.url}" class="cmp-download__title-link" href="${download.url}">${title}</a>

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/README.md
@@ -42,6 +42,7 @@ The following JCR properties are used:
 2. `./url` - defines the URL of the widget to embed.
 3. `./embeddableResourceType` - defines the resource type of an embeddable.
 4. `./html` - defines a HTML string to embed.
+5. `./id` - defines the component HTML ID attribute.
 
 ## BEM Description
 ```

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/_cq_dialog/.content.xml
@@ -160,6 +160,12 @@
                                                     cmp-embed-dialog-edit-type="true"
                                                     cmp-embed-dialog-edit-showhidetargetvalue="html"/>
                                             </html>
+                                            <id
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="HTML ID attribute to apply to the component."
+                                                fieldLabel="ID"
+                                                name="./id"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/embed.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/embed.html
@@ -14,8 +14,10 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.embed="com.adobe.cq.wcm.core.components.models.Embed"
+     data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-use.commonsTemplates="core/wcm/components/commons/v1/templates.html"
      data-sly-test.hasContent="${(embed.result && embed.result.processor) || embed.html || embed.embeddableResourceType}"
+     id="${component.id}"
      class="cmp-embed">
     <sly data-sly-test="${embed.result && embed.result.processor}"
          data-sly-use.processorTemplate="processors/${embed.result.processor}.html"

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/README.md
@@ -30,6 +30,7 @@ The experience fragment component uses the `com.adobe.cq.wcm.core.components.mod
 The following property is written to JCR for the experience fragment component and is expected to be available as a `Resource` property:
 
 1. `./fragmentVariationPath` - defines the path to the experience fragment variation to be rendered.
+2. `./id` - defines the component HTML ID attribute.
 
 ## BEM Description
 ```

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/_cq_dialog/.content.xml
@@ -58,6 +58,12 @@
                                                 variant="web"
                                                 fieldDescription="Choose the experience fragment variation to display.">
                                             </fragmentVariationPath>
+                                            <id
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="HTML ID attribute to apply to the component."
+                                                fieldLabel="ID"
+                                                name="./id"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/experiencefragment.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v1/experiencefragment/experiencefragment.html
@@ -14,9 +14,11 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.fragment="com.adobe.cq.wcm.core.components.models.ExperienceFragment"
+     data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-use.template="core/wcm/components/commons/v1/templates.html"
      data-sly-test.localizedFragmentVariationPath=${fragment.localizedFragmentVariationPath}
      data-sly-resource="${@path=localizedFragmentVariationPath, selectors='content', wcmmode='disabled'}"
+     id="${component.id}"
      class="cmp-experiencefragment cmp-experiencefragment--${fragment.name}">
 </div>
 <sly data-sly-call="${template.placeholder @ isEmpty=!localizedFragmentVariationPath, classAppend='cmp-dd-experiencefragment'}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/button/v2/button/button.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/button/v2/button/button.html
@@ -14,4 +14,8 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <button data-sly-use.button="com.adobe.cq.wcm.core.components.models.form.Button"
-        type="${button.type}" class="cmp-form-button" name="${button.name}" value="${button.value}">${button.title}</button>
+        type="${button.type}"
+        id="${button.id}"
+        class="cmp-form-button"
+        name="${button.name}"
+        value="${button.value}">${button.title}</button>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/README.md
@@ -39,6 +39,7 @@ The following properties are written to JCR for this Form Container component an
 3. `./workflowTitle` - defines the workflow's title
 4. `./redirect` - if left empty the form will be rendered after submission, otherwise the user will be redirected to the page stored by this
 property
+5. `./id` - defines the component HTML ID attribute.
 
 ## Client Libraries
 The component provides a `core.wcm.components.form.container.v2.editor` editor client library category that includes

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/container/v2/container/_cq_dialog/.content.xml
@@ -110,6 +110,12 @@
                                                 name="./redirect"
                                                 rootPath="/content"
                                                 wrapperClass="hide cmp-redirect-selection"/>
+                                            <id
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="HTML ID attribute to apply to the component."
+                                                fieldLabel="ID"
+                                                name="./id"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v1/hidden/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v1/hidden/README.md
@@ -28,7 +28,7 @@ The following properties are written to JCR for this Form Hidden component and a
 
 1. `./name` - defines the name of the field, which will be submitted with the form data
 2. `./value` - defines the value of the field, which will be submitted with the form data
-3. `./id` - defines the identifier of this field, which should be unique on the page
+3. `./id` - defines the component HTML ID attribute.
 
 ## Information
 * **Vendor**: Adobe

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v1/hidden/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v1/hidden/_cq_dialog/.content.xml
@@ -30,8 +30,8 @@
                     <identifier
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                        fieldDescription="The identifier should be unique on the page and can be used to bind scripts to this form field"
-                        fieldLabel="Identifier"
+                        fieldDescription="HTML ID attribute to apply to the component."
+                        fieldLabel="ID"
                         name="./id"/>
                 </items>
             </main>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v1/hidden/hidden.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v1/hidden/hidden.html
@@ -15,6 +15,6 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <input data-sly-use.field="com.adobe.cq.wcm.core.components.models.form.Field"
        data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
-       data-sly-test.appendText="${field.name && 'name='}${field.name}${field.value && ' | value='}${field.value}"
+       data-sly-set.appendText="${field.name && 'name='}${field.name}${field.value && ' | value='}${field.value}"
        data-sly-call="${templates.placeholder @ isEmpty = true, classAppend, emptyTextAppend = appendText}"
        type="hidden" id="${field.id}" name="${field.name}" value="${field.value}" />

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v2/hidden/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v2/hidden/README.md
@@ -28,7 +28,7 @@ The following properties are written to JCR for this Form Hidden component and a
 
 1. `./name` - defines the name of the field, which will be submitted with the form data
 2. `./value` - defines the value of the field, which will be submitted with the form data
-3. `./id` - defines the identifier of this field, which should be unique on the page
+3. `./id` - defines the component HTML ID attribute.
 
 ## Information
 * **Vendor**: Adobe

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v2/hidden/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v2/hidden/_cq_dialog/.content.xml
@@ -62,8 +62,8 @@
                                             <identifier
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                fieldDescription="The identifier should be unique on the page and can be used to bind scripts to this form field"
-                                                fieldLabel="Identifier"
+                                                fieldDescription="HTML ID attribute to apply to the component."
+                                                fieldLabel="ID"
                                                 name="./id"/>
                                         </items>
                                     </column>

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v2/hidden/hidden.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/hidden/v2/hidden/hidden.html
@@ -15,6 +15,6 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <input data-sly-use.field="com.adobe.cq.wcm.core.components.models.form.Field"
        data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
-       data-sly-test.appendText="${field.name && 'name='}${field.name}${field.value && ' | value='}${field.value}"
+       data-sly-set.appendText="${field.name && 'name='}${field.name}${field.value && ' | value='}${field.value}"
        data-sly-call="${templates.placeholder @ isEmpty = true, classAppend, emptyTextAppend = appendText}"
        type="hidden" id="${field.id}" name="${field.name}" value="${field.value}" />

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/amp.html
@@ -13,10 +13,12 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-
 <div data-sly-use.image="com.adobe.cq.wcm.core.components.models.Image"
+     data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
      data-sly-test="${image.src}"
+     id="${component.id}"
+     class="cmp-image${!wcmmode.disabled ? ' cq-dd-image' : ''}"
      data-cmp-is="image"
      data-cmp-lazy="${image.lazyEnabled}"
      data-cmp-src="${image.srcUriTemplate ? image.srcUriTemplate : image.src}"
@@ -24,7 +26,6 @@
      data-asset="${image.fileReference}"
      data-asset-id="${image.uuid}"
      data-title="${image.title || image.alt}"
-     class="cmp-image${!wcmmode.disabled ? ' cq-dd-image' : ''}"
      itemscope itemtype="http://schema.org/ImageObject">
 
   <a data-sly-unwrap="${!image.link}"
@@ -39,7 +40,7 @@
           data-sly-attribute.usemap="${image.areas ? usemap : ''}"
           layout="fill"
           title="${image.displayPopupTitle && image.title}"/>
-      </div>                  
+      </div>
 
       <map data-sly-test="${image.areas}"
             data-sly-list.area="${image.areas}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/image.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/image.html
@@ -14,6 +14,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.image="com.adobe.cq.wcm.core.components.models.Image"
+     data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
      data-sly-test="${image.src}"
      data-cmp-is="image"
@@ -23,6 +24,7 @@
      data-asset="${image.fileReference}"
      data-asset-id="${image.uuid}"
      data-title="${image.title || image.alt}"
+     id="${component.id}"
      class="cmp-image${!wcmmode.disabled ? ' cq-dd-image' : ''}"
      itemscope itemtype="http://schema.org/ImageObject">
     <a data-sly-unwrap="${!image.link}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v1/languagenavigation/languagenavigation.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/languagenavigation/v1/languagenavigation/languagenavigation.html
@@ -13,11 +13,13 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<nav class="cmp-languagenavigation"
+<nav data-sly-use.languageNavigation="com.adobe.cq.wcm.core.components.models.LanguageNavigation"
+     data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-use.commonsTemplates="core/wcm/components/commons/v1/templates.html"
-     data-sly-use.languageNavigation="com.adobe.cq.wcm.core.components.models.LanguageNavigation"
-     data-sly-test.hasContent="${languageNavigation.items.size > 0}"
      data-sly-use.groupTemplate="group.html"
-     data-sly-call="${groupTemplate.group @ items=languageNavigation.items}">
+     data-sly-call="${groupTemplate.group @ items=languageNavigation.items}"
+     data-sly-test.hasContent="${languageNavigation.items.size > 0}"
+     id="${component.id}"
+     class="cmp-languagenavigation">
 </nav>
 <sly data-sly-call="${commonsTemplates.placeholder @ isEmpty = !hasContent, classAppend='cmp-languagenavigation'}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/list/v2/list/list.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/list/v2/list/list.html
@@ -14,9 +14,11 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <ul data-sly-use.list="com.adobe.cq.wcm.core.components.models.List"
-    data-sly-list.item="${list.listItems}"
+    data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
     data-sly-use.template="core/wcm/components/commons/v1/templates.html"
     data-sly-use.itemTemplate="item.html"
+    data-sly-list.item="${list.listItems}"
+    id="${component.id}"
     class="cmp-list">
     <li class="cmp-list__item" data-sly-call="${itemTemplate.item @ list = list, item = item}"></li>
 </ul>

--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/navigation.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/navigation.html
@@ -13,14 +13,16 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<nav class="cmp-navigation"
-     role="navigation"
-     itemscope itemtype="http://schema.org/SiteNavigationElement"
+<nav data-sly-use.navigation="com.adobe.cq.wcm.core.components.models.Navigation"
+     data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-use.template="core/wcm/components/commons/v1/templates.html"
-     data-sly-use.navigation="com.adobe.cq.wcm.core.components.models.Navigation"
-     data-sly-test.hasContent="${navigation.items.size > 0}"
      data-sly-use.groupTemplate="group.html"
      data-sly-call="${groupTemplate.group @ items=navigation.items}"
+     data-sly-test.hasContent="${navigation.items.size > 0}"
+     id="${component.id}"
+     class="cmp-navigation"
+     role="navigation"
+     itemscope itemtype="http://schema.org/SiteNavigationElement"
      aria-label="${navigation.accessibilityLabel}">
 </nav>
 <sly data-sly-call="${template.placeholder @ isEmpty=!hasContent, classAppend='cmp-navigation'}"></sly>

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/amp.html
@@ -14,6 +14,8 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <section data-sly-use.search="com.adobe.cq.wcm.core.components.models.Search"
+         data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
+         id="${component.id}"
          class="cmp-search"
          role="search">
     <form class="cmp-search__form"

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/search.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/search.html
@@ -13,8 +13,11 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<section class="cmp-search" role="search"
-         data-sly-use.search="com.adobe.cq.wcm.core.components.models.Search"
+<section data-sly-use.search="com.adobe.cq.wcm.core.components.models.Search"
+         data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
+         id="${component.id}"
+         class="cmp-search"
+         role="search"
          data-cmp-is="search"
          data-cmp-min-length="${search.searchTermMinimumLength}"
          data-cmp-results-size="${search.resultsSize}">

--- a/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/separator.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/separator/v1/separator/separator.html
@@ -13,6 +13,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<div class="cmp-separator">
+<div data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
+     id="${component.id}"
+     class="cmp-separator">
     <hr class="cmp-separator__horizontal-rule"/>
 </div>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/README.md
@@ -34,7 +34,8 @@ The component policy dialog allows definition of allowed components for the Tabs
 The following properties are written to JCR for this Tabs component and are expected to be available as `Resource` properties:
 
 1. `./activeItem` - defines the name of the item that is active by default.
-2. `./accessibilityLabel` - defines an accessibility label for the tabs.
+2. `./id` - defines the component HTML ID attribute.
+3. `./accessibilityLabel` - defines an accessibility label for the tabs.
 
 The edit dialog also allows editing of Tabs items (adding, removing, naming, re-ordering).
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/_cq_dialog/.content.xml
@@ -95,6 +95,12 @@
                                                         value=""/>
                                                 </items>
                                             </activeSelect>
+                                            <id
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="HTML ID attribute to apply to the component."
+                                                fieldLabel="ID"
+                                                name="./id"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
@@ -17,17 +17,18 @@
               data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
               data-sly-test="${tabs.items && tabs.items.size > 0}"
               data-sly-list.item="${tabs.items}"
+              id="${tabs.id}"
               class="cmp-tabs tabs-with-flex"
               role="tablist">
-    <div id="tab-item${tabs.tabsId}-${itemList.index}"
+    <div id="${tabs.id}-tab-${itemList.index}"
          class="cmp-tabs__tab"
          option
          selected="${item.name == tabs.activeItem}"
          role="tab"
-         aria-controls="tab-panel${tabs.tabsId}-${itemList.index}">${item.title}</div>
-    <div id="tab-panel${tabs.tabsId}-${itemList.index}"
-         aria-labelledby="tab-item${tabs.tabsId}-${itemList.index}"
+         aria-controls="${tabs.id}-tabpanel-${itemList.index}">${item.title}</div>
+    <div id="${tabs.id}-tabpanel-${itemList.index}"
+         class="cmp-tabs__tabpanel"
+         aria-labelledby="${tabs.id}-tab-${itemList.index}"
          data-sly-resource="${item.name @ decorationTagName='div'}"
-         role="tabpanel"
-         class="cmp-tabs__tabpanel"></div>
+         role="tabpanel"></div>
 </amp-selector>

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/tabs.html
@@ -15,6 +15,7 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.tabs="com.adobe.cq.wcm.core.components.models.Tabs"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
+     id="${tabs.id}"
      class="cmp-tabs"
      data-cmp-is="tabs">
     <ol data-sly-test="${tabs.items && tabs.items.size > 0}"
@@ -25,13 +26,17 @@
         aria-multiselectable="false">
         <sly data-sly-test.isActive="${tab.name == tabs.activeItem}"/>
         <li role="tab"
+            id="${tabs.id}-tab-${tabList.index}"
             class="cmp-tabs__tab${isActive ? ' cmp-tabs__tab--active' : ''}"
+            aria-controls="${tabs.id}-tabpanel-${tabList.index}"
             tabindex="${isActive ? '0' : '-1'}"
             data-cmp-hook-tabs="tab">${tab.title}</li>
     </ol>
     <div data-sly-repeat.item="${tabs.items}"
          data-sly-resource="${item.name @ decorationTagName='div'}"
+         id="${tabs.id}-tabpanel-${itemList.index}"
          role="tabpanel"
+         aria-labelledby="${tabs.id}-tab-${itemList.index}"
          tabindex="0"
          class="cmp-tabs__tabpanel${item.name == tabs.activeItem ? ' cmp-tabs__tabpanel--active' : ''}"
          data-cmp-hook-tabs="tabpanel"></div>

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -40,7 +40,7 @@
                                                 fieldLabel="Image Asset"
                                                 fileNameParameter="./fileName"
                                                 fileReferenceParameter="./fileReference"
-                                                mimeTypes="[image/gif,image/jpeg,image/png,image/tiff]"
+                                                mimeTypes="[image/gif,image/jpeg,image/png,image/tiff,image/svg+xml]"
                                                 multiple="{Boolean}false"
                                                 name="./file"
                                                 title="Upload Image Asset"

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/teaser.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/teaser.html
@@ -14,6 +14,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.teaser="com.adobe.cq.wcm.core.components.models.Teaser"
+     data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
      data-sly-use.imageTemplate="image.html"
      data-sly-use.pretitleTemplate="pretitle.html"
@@ -21,6 +22,7 @@
      data-sly-use.descriptionTemplate="description.html"
      data-sly-use.actionsTemplate="actions.html"
      data-sly-test.hasContent="${teaser.imageResource || teaser.pretitle || teaser.title || teaser.description || teaser.actions.size > 0}"
+     id="${component.id}"
      class="cmp-teaser${!wcmmode.disabled && teaser.imageResource ? ' cq-dd-image' : ''}">
     <sly data-sly-call="${imageTemplate.image @ teaser=teaser}"></sly>
     <div class="cmp-teaser__content">

--- a/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/text.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text/text.html
@@ -14,8 +14,10 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <div data-sly-use.textModel="com.adobe.cq.wcm.core.components.models.Text"
+     data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
      data-sly-test.text="${textModel.text}"
+     id="${component.id}"
      class="cmp-text">
     <p class="cmp-text__paragraph"
        data-sly-unwrap="${textModel.isRichText}">${text @ context = textModel.isRichText ? 'html' : 'text'}</p>

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/README.md
@@ -41,6 +41,7 @@ The following properties are written to JCR for this Title component and are exp
 2. `./type` - will store the HTML heading element type which will be used for rendering; if no value is defined, the component will fallback
 to the value defined by the component's policy
 3. `./linkURL` - will allow definition of a content page path, external URL or page anchor for linking the title.
+4. `./id` - defines the component HTML ID attribute.
 
 ## Client Libraries
 The component provides a `core.wcm.components.title.v2.editor` editor client library category that includes JavaScript

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/_cq_dialog/.content.xml
@@ -91,6 +91,12 @@
                                                     sling:resourceType="granite/ui/components/foundation/renderconditions/simple"
                                                     expression="${!cqDesign.linkDisabled}"/>
                                             </linkURL>
+                                            <id
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="HTML ID attribute to apply to the component."
+                                                fieldLabel="ID"
+                                                name="./id"/>
                                         </items>
                                     </column>
                                 </items>

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/title.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/title.html
@@ -13,10 +13,12 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<div class="cmp-title"
-     data-sly-use.title="com.adobe.cq.wcm.core.components.models.Title"
+<div data-sly-use.title="com.adobe.cq.wcm.core.components.models.Title"
+     data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-use.template="core/wcm/components/commons/v1/templates.html"
-     data-sly-test.text="${title.text}">
+     data-sly-test.text="${title.text}"
+     id="${component.id}"
+     class="cmp-title">
     <h1 class="cmp-title__text" data-sly-element="${title.type}"><a data-sly-unwrap="${!title.linkURL || title.linkDisabled}" class="cmp-title__link" href="${title.linkURL}">${text}</a></h1>
 </div>
 <sly data-sly-call="${template.placeholder @ isEmpty=!text, classAppend='cmp-title'}"></sly>

--- a/examples/ui.apps/pom.xml
+++ b/examples/ui.apps/pom.xml
@@ -79,6 +79,12 @@
                         <configuration>
                             <generateJavaClasses>true</generateJavaClasses>
                             <generatedJavaClassesPrefix>org.apache.sling.scripting.sightly</generatedJavaClassesPrefix>
+                            <allowedExpressionOptions>
+                                <allowedExpressionOption>cssClassName</allowedExpressionOption>
+                                <allowedExpressionOption>decoration</allowedExpressionOption>
+                                <allowedExpressionOption>decorationTagName</allowedExpressionOption>
+                                <allowedExpressionOption>wcmmode</allowedExpressionOption>
+                            </allowedExpressionOptions>
                         </configuration>
                     </execution>
                 </executions>
@@ -217,13 +223,13 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.scripting.sightly.compiler</artifactId>
-            <version>1.0.14</version>
+            <version>1.2.4-1.4.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.scripting.sightly.compiler.java</artifactId>
-            <version>1.0.16</version>
+            <artifactId>org.apache.sling.scripting.sightly.runtime</artifactId>
+            <version>1.2.0-1.4.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/accordion.less
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-site/styles/components/accordion.less
@@ -39,6 +39,7 @@
         font-size: @cmp-examples-font-size-s;
         font-weight: @cmp-examples-font-weight-bold;
         color: @cmp-examples-color-gray-800;
+        background-color: transparent;
 
         &:hover {
             background-color: @cmp-examples-color-gray-200;

--- a/examples/ui.content/src/content/jcr_root/content/experience-fragments/core-components-examples/library/simple-experience-fragment/master/.content.xml
+++ b/examples/ui.content/src/content/jcr_root/content/experience-fragments/core-components-examples/library/simple-experience-fragment/master/.content.xml
@@ -21,7 +21,7 @@
                 jcr:lastModified="{Date}2019-07-17T15:17:32.534+02:00"
                 jcr:lastModifiedBy="admin"
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="core/wcm/components/text/v1/text"
+                sling:resourceType="core/wcm/components/text/v2/text"
                 text="&lt;p>Lava forming some rock.&lt;/p>&#xd;&#xa;"
                 textIsRich="true"/>
             <image

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -680,6 +680,12 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.14</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>2.5</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -368,7 +368,7 @@
                 <plugin>
                     <groupId>org.apache.sling</groupId>
                     <artifactId>htl-maven-plugin</artifactId>
-                    <version>1.2.0-1.4.0</version>
+                    <version>1.3.4-1.4.0</version>
                     <configuration>
                         <failOnWarnings>true</failOnWarnings>
                     </configuration>


### PR DESCRIPTION
An approach for generic auto-generated component IDs was added in the base project in https://github.com/adobe/aem-core-wcm-components/pull/912. This pull request updates the AMP feature for that change.

• removes `Tabs#getTabsId`, this is now handled in the `AbstractComponentImpl`.
• updates related test resources.
• downgrades unnecessary core component models version bump.
• applies generic ids to amp HTL files.