### PR TITLE
[AMP] Updates for generic component IDs

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
@@ -82,14 +82,4 @@ public class TabsImpl extends PanelContainerImpl implements Tabs {
     public String getAccessibilityLabel() {
         return accessibilityLabel;
     }
-
-    @Override
-    public String getTabsId() {
-        String resourcePath = resource.getPath();
-        String identifier = resourcePath.substring(resourcePath.indexOf(JCR_CONTENT) + JCR_CONTENT.length());
-        if (resourcePath.startsWith("/conf")) {
-            identifier += "-template";
-        }
-        return identifier.replace("/", "-");
-    }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
@@ -44,14 +44,4 @@ public interface Tabs extends Container {
     default String getAccessibilityLabel() {
         throw new UnsupportedOperationException();
     }
-
-    /**
-     * Returns an unique ID for the tab based on resource path.
-     *
-     * @return an UID for tabs
-     * @since com.adobe.cq.wcm.core.components.models 12.13.0
-     */
-    default String getTabsId() {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.14.0")
+@Version("12.12.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/resources/tabs/exporter-tabs1.json
+++ b/bundles/core/src/test/resources/tabs/exporter-tabs1.json
@@ -1,7 +1,6 @@
 {
     "id": "tabs-5d4d947d94",
     "activeItem": "item_2",
-    "tabsId": "-root-responsivegrid-tabs-1",
     ":itemsOrder": [
         "item_1",
         "item_2"

--- a/bundles/core/src/test/resources/tabs/exporter-tabs2.json
+++ b/bundles/core/src/test/resources/tabs/exporter-tabs2.json
@@ -1,7 +1,6 @@
 {
     "id": "tabs-7e84106a6a",
     "activeItem": "item_2",
-    "tabsId": "-root-responsivegrid-tabs-2",
     ":itemsOrder": [
         "item_1",
         "item_2"
@@ -21,7 +20,6 @@
                 "item_1_2": {
                     "id": "tabs-e14a27b1c3",
                     "activeItem": "item_1_2_2",
-                    "tabsId": "-root-responsivegrid-tabs-2-item_1-item_1_2",
                     ":itemsOrder": [
                         "item_1_2_1",
                         "item_1_2_2"

--- a/bundles/core/src/test/resources/tabs/exporter-tabs3.json
+++ b/bundles/core/src/test/resources/tabs/exporter-tabs3.json
@@ -1,6 +1,6 @@
 {
     "activeItem": "item_1",
-    "tabsId": "-root-responsivegrid-tabs-3",
+    "id":"tabs-bd3cb85fb2",
     ":itemsOrder": [
         "item_1",
         "item_2"

--- a/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/accordion/v1/accordion/amp.html
@@ -15,18 +15,23 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <amp-accordion data-sly-use.accordion="com.adobe.cq.wcm.core.components.models.Accordion"
                data-sly-test="${accordion.items && accordion.items.size > 0}"
+               id="${accordion.id}"
                class="cmp-accordion"
                expand-single-section="${accordion.singleExpansion}">
     <section data-sly-repeat.item="${accordion.items}"
              class="cmp-accordion__item"
              expanded="${item.name in accordion.expandedItems}">
         <h3 data-sly-element="${accordion.headingElement @ context='elementName'}"
-            class="cmp-accordion__header">
+            id="${accordion.id}-button-${itemList.index}"
+            class="cmp-accordion__button"
+            aria-controls="${accordion.id}-panel-${itemList.index}">
             <span class="cmp-accordion__title">${item.title}</span>
             <span class="cmp-accordion__icon"></span>
         </h3>
         <div data-sly-resource="${item.name @ decorationTagName='div'}"
+             id="${accordion.id}-panel-${itemList.index}"
              class="cmp-accordion__panel"
-             role="region"></div>
+             role="region"
+             aria-labelledby="${accordion.id}-button-${itemList.index}"></div>
     </section>
 </amp-accordion>

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/amp.html
@@ -16,6 +16,7 @@
 <amp-carousel data-sly-use.carousel="com.adobe.cq.wcm.core.components.models.Carousel"
               data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
               data-sly-test="${carousel.items && carousel.items.size > 0}"
+              id="${carousel.id}"
               class="cmp-carousel"
               role="group"
               aria-label="${carousel.accessibilityLabel}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/amp.html
@@ -13,10 +13,12 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-
 <div data-sly-use.image="com.adobe.cq.wcm.core.components.models.Image"
+     data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
      data-sly-test="${image.src}"
+     id="${component.id}"
+     class="cmp-image${!wcmmode.disabled ? ' cq-dd-image' : ''}"
      data-cmp-is="image"
      data-cmp-lazy="${image.lazyEnabled}"
      data-cmp-src="${image.srcUriTemplate ? image.srcUriTemplate : image.src}"
@@ -24,7 +26,6 @@
      data-asset="${image.fileReference}"
      data-asset-id="${image.uuid}"
      data-title="${image.title || image.alt}"
-     class="cmp-image${!wcmmode.disabled ? ' cq-dd-image' : ''}"
      itemscope itemtype="http://schema.org/ImageObject">
 
   <a data-sly-unwrap="${!image.link}"
@@ -39,7 +40,7 @@
           data-sly-attribute.usemap="${image.areas ? usemap : ''}"
           layout="fill"
           title="${image.displayPopupTitle && image.title}"/>
-      </div>                  
+      </div>
 
       <map data-sly-test="${image.areas}"
             data-sly-list.area="${image.areas}"

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/amp.html
@@ -14,6 +14,8 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <section data-sly-use.search="com.adobe.cq.wcm.core.components.models.Search"
+         data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
+         id="${component.id}"
          class="cmp-search"
          role="search">
     <form class="cmp-search__form"

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/amp.html
@@ -17,17 +17,18 @@
               data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
               data-sly-test="${tabs.items && tabs.items.size > 0}"
               data-sly-list.item="${tabs.items}"
+              id="${tabs.id}"
               class="cmp-tabs tabs-with-flex"
               role="tablist">
-    <div id="tab-item${tabs.tabsId}-${itemList.index}"
+    <div id="${tabs.id}-tab-${itemList.index}"
          class="cmp-tabs__tab"
          option
          selected="${item.name == tabs.activeItem}"
          role="tab"
-         aria-controls="tab-panel${tabs.tabsId}-${itemList.index}">${item.title}</div>
-    <div id="tab-panel${tabs.tabsId}-${itemList.index}"
-         aria-labelledby="tab-item${tabs.tabsId}-${itemList.index}"
+         aria-controls="${tabs.id}-tabpanel-${itemList.index}">${item.title}</div>
+    <div id="${tabs.id}-tabpanel-${itemList.index}"
+         class="cmp-tabs__tabpanel"
+         aria-labelledby="${tabs.id}-tab-${itemList.index}"
          data-sly-resource="${item.name @ decorationTagName='div'}"
-         role="tabpanel"
-         class="cmp-tabs__tabpanel"></div>
+         role="tabpanel"></div>
 </amp-selector>


### PR DESCRIPTION
An approach for generic auto-generated component IDs was added in the base project in https://github.com/adobe/aem-core-wcm-components/pull/912. This pull request updates the AMP feature for that change.

• removes `Tabs#getTabsId`, this is now handled in the `AbstractComponentImpl`.
• updates related test resources.
• downgrades unnecessary core component models version bump.
• applies generic ids to amp HTL files.