### PR TITLE
Removing dedicated Tabs ID approach and using generic component ID approach

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/TabsImpl.java
@@ -83,13 +83,4 @@ public class TabsImpl extends PanelContainerImpl implements Tabs {
         return accessibilityLabel;
     }
 
-    @Override
-    public String getTabsId() {
-        String resourcePath = resource.getPath();
-        String identifier = resourcePath.substring(resourcePath.indexOf(JCR_CONTENT) + JCR_CONTENT.length());
-        if (resourcePath.startsWith("/conf")) {
-            identifier += "-template";
-        }
-        return identifier.replace("/", "-");
-    }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Tabs.java
@@ -45,13 +45,4 @@ public interface Tabs extends Container {
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * Returns an unique ID for the tab based on resource path.
-     *
-     * @return an UID for tabs
-     * @since com.adobe.cq.wcm.core.components.models 12.13.0
-     */
-    default String getTabsId() {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/bundles/core/src/test/resources/tabs/exporter-tabs1.json
+++ b/bundles/core/src/test/resources/tabs/exporter-tabs1.json
@@ -1,7 +1,6 @@
 {
     "id": "tabs-3dc934841b",
     "activeItem": "item_2",
-    "tabsId": "-root-responsivegrid-tabs-1",
     ":itemsOrder": [
         "item_1",
         "item_2"

--- a/bundles/core/src/test/resources/tabs/exporter-tabs2.json
+++ b/bundles/core/src/test/resources/tabs/exporter-tabs2.json
@@ -1,7 +1,6 @@
 {
     "id": "tabs-673620f4d1",
     "activeItem": "item_2",
-    "tabsId": "-root-responsivegrid-tabs-2",
     ":itemsOrder": [
         "item_1",
         "item_2"
@@ -21,7 +20,6 @@
                 "item_1_2": {
                     "id": "tabs-c2dc9e45de",
                     "activeItem": "item_1_2_2",
-                    "tabsId": "-root-responsivegrid-tabs-2-item_1-item_1_2",
                     ":itemsOrder": [
                         "item_1_2_1",
                         "item_1_2_2"

--- a/bundles/core/src/test/resources/tabs/exporter-tabs3.json
+++ b/bundles/core/src/test/resources/tabs/exporter-tabs3.json
@@ -1,7 +1,6 @@
 {
-    "id": "tabs-73c57b3627",
+    "id":"tabs-bd3cb85fb2",
     "activeItem": "item_1",
-    "tabsId": "-root-responsivegrid-tabs-3",
     ":itemsOrder": [
         "item_1",
         "item_2"

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/accordion/v1/accordion/amp.html
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/accordion/v1/accordion/amp.html
@@ -15,18 +15,23 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <amp-accordion data-sly-use.accordion="com.adobe.cq.wcm.core.components.models.Accordion"
                data-sly-test="${accordion.items && accordion.items.size > 0}"
+               id="${accordion.id}"
                class="cmp-accordion"
                expand-single-section="${accordion.singleExpansion}">
     <section data-sly-repeat.item="${accordion.items}"
              class="cmp-accordion__item"
              expanded="${item.name in accordion.expandedItems}">
         <h3 data-sly-element="${accordion.headingElement @ context='elementName'}"
-            class="cmp-accordion__header">
+            id="${accordion.id}-button-${itemList.index}"
+            class="cmp-accordion__button"
+            aria-controls="${accordion.id}-panel-${itemList.index}">
             <span class="cmp-accordion__title">${item.title}</span>
             <span class="cmp-accordion__icon"></span>
         </h3>
         <div data-sly-resource="${item.name @ decorationTagName='div'}"
+             id="${accordion.id}-panel-${itemList.index}"
              class="cmp-accordion__panel"
-             role="region"></div>
+             role="region"
+             aria-labelledby="${accordion.id}-button-${itemList.index}"></div>
     </section>
 </amp-accordion>

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/carousel/v1/carousel/amp.html
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/carousel/v1/carousel/amp.html
@@ -16,6 +16,7 @@
 <amp-carousel data-sly-use.carousel="com.adobe.cq.wcm.core.components.models.Carousel"
               data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
               data-sly-test="${carousel.items && carousel.items.size > 0}"
+              id="${carousel.id}"
               class="cmp-carousel"
               role="group"
               aria-label="${carousel.accessibilityLabel}"

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/image/v1/image/amp.html
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/image/v1/image/amp.html
@@ -15,6 +15,7 @@
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 
 <div data-sly-use.image="com.adobe.cq.wcm.core.components.models.Image"
+     data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
      data-sly-test="${image.src}"
      data-cmp-is="image"
@@ -24,6 +25,7 @@
      data-asset="${image.fileReference}"
      data-asset-id="${image.uuid}"
      data-title="${image.title || image.alt}"
+     id="${component.id}"
      class="cmp-image${!wcmmode.disabled ? ' cq-dd-image' : ''}"
      itemscope itemtype="http://schema.org/ImageObject">
 

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/search/v1/search/amp.html
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/search/v1/search/amp.html
@@ -14,6 +14,8 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <section data-sly-use.search="com.adobe.cq.wcm.core.components.models.Search"
+         data-sly-use.component="com.adobe.cq.wcm.core.components.models.Component"
+         id="${component.id}"
          class="cmp-search"
          role="search">
     <form class="cmp-search__form"

--- a/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/tabs/v1/tabs/amp.html
+++ b/extensions/amp/content/src/content/jcr_root/apps/core/wcm/extensions/amp/components/tabs/v1/tabs/amp.html
@@ -16,18 +16,19 @@
 <amp-selector data-sly-use.tabs="com.adobe.cq.wcm.core.components.models.Tabs"
               data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
               data-sly-test="${tabs.items && tabs.items.size > 0}"
+              id="${tabs.id}"
               data-sly-list.item="${tabs.items}"
               class="cmp-tabs tabs-with-flex"
               role="tablist">
-    <div id="tab-item${tabs.tabsId}-${itemList.index}"
+    <div id="${tabs.id}-tab-${itemList.index}"
          class="cmp-tabs__tab"
          option
          selected="${item.name == tabs.activeItem}"
          role="tab"
-         aria-controls="tab-panel${tabs.tabsId}-${itemList.index}">${item.title}</div>
-    <div id="tab-panel${tabs.tabsId}-${itemList.index}"
-         aria-labelledby="tab-item${tabs.tabsId}-${itemList.index}"
+         aria-controls="${tabs.id}-tabpanel-${itemList.index}">${item.title}</div>
+    <div id="${tabs.id}-tabpanel-${itemList.index}"
+         class="cmp-tabs__tabpanel"
+         aria-labelledby="${tabs.id}-tab-${itemList.index}"
          data-sly-resource="${item.name @ decorationTagName='div'}"
-         role="tabpanel"
-         class="cmp-tabs__tabpanel"></div>
+         role="tabpanel"></div>
 </amp-selector>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Using generic component ID approach for AMP components
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      | No
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
An approach for generic auto-generated component IDs was added in the base project in adobe#912. This pull request updates the AMP feature for that change.

• removes Tabs#getTabsId, this is now handled in the AbstractComponentImpl.
• updates related test resources.
• applies generic ids to amp HTL files.